### PR TITLE
Clean up HODLR-Vector algebra

### DIFF
--- a/src/vector_algebra.c
+++ b/src/vector_algebra.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <stdlib.h>
 
 #include "../include/tree.h"
@@ -48,55 +47,43 @@
  *                    so is an undefined behaviour. Similarly, it must not be
  *                    ``NULL`` - again undefined.
  */
-static inline void multiply_off_diagonal_vector(
+static inline int multiply_off_diagonal_vector(
   const struct HODLRInternalNode *restrict parent,
   const double *restrict vector,
   double *restrict out,
   double *restrict workspace,
-  double *restrict workspace2,
-  const double alpha,
-  const double beta,
   const int increment,
-  int *restrict offset_ptr
+  const int offset
 ) {
-  int i = 0;
-  int m = parent->children[1].leaf->data.off_diagonal.m;
-  int n = parent->children[1].leaf->data.off_diagonal.n;
+  const double one = 1.0, zero = 0.0;
+  const int m = parent->children[1].leaf->data.off_diagonal.m;
+  const int n = parent->children[1].leaf->data.off_diagonal.n;
   int s = parent->children[1].leaf->data.off_diagonal.s;
 
-  int offset2 = *offset_ptr;
-  *offset_ptr += m;
-  int offset = *offset_ptr;
+  const int offset2 = offset + m;
 
-  dgemv_("T", &n, &s, &alpha, 
+  dgemv_("T", &n, &s, &one, 
           parent->children[1].leaf->data.off_diagonal.v, 
-          &n, vector + offset, &increment, 
-          &beta, workspace, &increment);
+          &n, vector + offset2, &increment, 
+          &zero, workspace, &increment);
 
-  dgemv_("N", &m, &s, &alpha, 
+  dgemv_("N", &m, &s, &one, 
           parent->children[1].leaf->data.off_diagonal.u, 
           &m, workspace, &increment,
-          &beta, workspace2, &increment);
+          &one, out + offset, &increment);
 
-  for (i = 0; i < m; i++) {
-    out[offset2 + i] += workspace2[i];
-  }
-  
   s = parent->children[2].leaf->data.off_diagonal.s;
-  dgemv_("T", &m, &s, &alpha, 
+  dgemv_("T", &m, &s, &one, 
           parent->children[2].leaf->data.off_diagonal.v, 
-          &m, vector + offset2, &increment, 
-          &beta, workspace, &increment);
+          &m, vector + offset, &increment, 
+          &zero, workspace, &increment);
 
-  dgemv_("N", &n, &s, &alpha, 
+  dgemv_("N", &n, &s, &one, 
           parent->children[2].leaf->data.off_diagonal.u, 
           &n, workspace, &increment,
-          &beta, workspace2, &increment);
+          &one, out + offset2, &increment);
 
-  for (i = 0; i < n; i++) {
-    out[offset + i] += workspace2[i];
-  }
-  *offset_ptr += n;
+  return offset2 + n;
 }
 
 
@@ -138,28 +125,27 @@ double * multiply_vector(const struct TreeHODLR *restrict hodlr,
     }
   }
 
-  int offset = 0, i=0, j=0, k=0, idx=0, m = 0;
+  int offset = 0, idx=0, m = 0;
   const int increment = 1;
   const double alpha = 1, beta = 0;
   long n_parent_nodes = hodlr->len_work_queue;
 
   const int largest_m = hodlr->root->children[1].leaf->data.off_diagonal.m ;
-  double *workspace = malloc(2 * largest_m * sizeof(double));
-  double *workspace2 = workspace + largest_m;
+  double *workspace = malloc(largest_m * sizeof(double));
 
   struct HODLRInternalNode **queue = hodlr->work_queue;
 
-  for (i = 0; i < n_parent_nodes; i++) {
-    queue[i] = hodlr->innermost_leaves[2 * i]->parent;
+  for (int parent = 0; parent < n_parent_nodes; parent++) {
+    queue[parent] = hodlr->innermost_leaves[2 * parent]->parent;
 
-    for (j = 0; j < 2; j++) {
-      idx = 2 * i + j;
+    for (int j = 0; j < 2; j++) {
       m = hodlr->innermost_leaves[idx]->data.diagonal.m;
       dgemv_("N", &m, &m, &alpha, 
              hodlr->innermost_leaves[idx]->data.diagonal.data, 
              &m, vector + offset, &increment, 
              &beta, out + offset, &increment);
       offset += m;
+      idx++;
     }
   }
 
@@ -167,12 +153,11 @@ double * multiply_vector(const struct TreeHODLR *restrict hodlr,
     n_parent_nodes /= 2;
     offset = 0;
 
-    for (j = 0; j < n_parent_nodes; j++) {
+    for (int j = 0; j < n_parent_nodes; j++) {
       idx = 2 * j;
-      for (k = 0; k < 2; k++) {
-        multiply_off_diagonal_vector(
-          queue[idx], vector, out, workspace, workspace2, 
-          alpha, beta, increment, &offset
+      for (int k = 0; k < 2; k++) {
+        offset = multiply_off_diagonal_vector(
+          queue[idx], vector, out, workspace, increment, offset
         );
 
         idx += 1;
@@ -182,10 +167,8 @@ double * multiply_vector(const struct TreeHODLR *restrict hodlr,
     }
   }
 
-  offset = 0;
   multiply_off_diagonal_vector(
-    hodlr->root, vector, out, workspace, workspace2, 
-    alpha, beta, increment, &offset
+    hodlr->root, vector, out, workspace, increment, 0
   );
 
   free(workspace);

--- a/tests/src/test_vector_algebra.c
+++ b/tests/src/test_vector_algebra.c
@@ -19,6 +19,14 @@
 #define STR_LEN 10
 
 
+static inline void fill_full_vector(const int len, const double val, 
+                                    double *vector) {
+  for (int i = 0; i < len; i++) {
+    vector[i] = val;
+  }
+}
+
+
 struct ParametersTestHxV {
   struct TreeHODLR *hodlr;
   double *vector;
@@ -36,7 +44,6 @@ void free_hv_params(struct criterion_test_params *params) {
     free_tree_hodlr(&(param->hodlr), &cr_free);
     cr_free(param->expected);
     cr_free(param->vector);
-    //cr_free(param);
   }
   cr_free(params->params);
 }
@@ -148,7 +155,8 @@ int identity_matrix(struct ParametersTestHxV *params) {
 struct ParametersTestHxV * generate_hodlr_vector_params(int * len) {
   const int n_params = 9+9;
   *len = n_params;
-  struct ParametersTestHxV *params = cr_malloc(n_params * sizeof(struct ParametersTestHxV));
+  struct ParametersTestHxV *params = 
+    cr_malloc(n_params * sizeof(struct ParametersTestHxV));
 
   int actual = laplacian_matrix(params);
   actual += identity_matrix(params + actual);
@@ -184,4 +192,157 @@ ParameterizedTest(struct ParametersTestHxV *params, vector_algebra,
 
   free(result);
 }
+
+
+struct ParametersTestOffdiagxV {
+  struct HODLRInternalNode *parent;
+  double *vector;
+  double *out;
+  double *expected;
+  int len;
+  int offset;
+  char hodlr_name[STR_LEN];
+  char vector_name[STR_LEN];
+  char out_name[STR_LEN];
+};
+
+
+void free_ov_params(struct criterion_test_params *params) {
+  for (int i = 0; i < params->length; i++) {
+    struct ParametersTestOffdiagxV *param = 
+      (struct ParametersTestOffdiagxV *) params->params + i;
+
+    for (int i = 1; i < 3; i++) {
+      cr_free(param->parent->children[i].leaf->data.off_diagonal.u);
+      cr_free(param->parent->children[i].leaf->data.off_diagonal.v);
+      cr_free(param->parent->children[i].leaf);
+    }
+    cr_free(param->parent);
+
+    cr_free(param->expected);
+    cr_free(param->out);
+    cr_free(param->vector);
+  }
+  cr_free(params->params);
+}
+
+
+ParameterizedTestParameters(vector_algebra, multiply_off_diagonal_vector) {
+  const int n_params = 3;
+  struct ParametersTestOffdiagxV *params = 
+    cr_malloc(n_params * sizeof(struct ParametersTestOffdiagxV));
+
+  const int lens[] = {20, 10, 19};
+  const int ms[] = {6, 4, 8};
+  const int ns[] = {5, 4, 7};
+  const int ss[] = {1, 1, 1};
+  const int offsets[] = {5, 2, 3};
+
+  for (int i = 0; i < n_params; i++) {
+    params[i].parent = cr_malloc(sizeof(struct HODLRInternalNode));
+    params[i].parent->children[1].leaf = 
+      cr_malloc(sizeof(struct NodeOffDiagonal));
+    params[i].parent->children[1].leaf->data.off_diagonal.u =
+      cr_calloc(ms[i] * ss[i], sizeof(double));
+    params[i].parent->children[1].leaf->data.off_diagonal.v =
+      cr_calloc(ns[i] * ss[i], sizeof(double));
+    params[i].parent->children[1].leaf->data.off_diagonal.m = ms[i];
+    params[i].parent->children[1].leaf->data.off_diagonal.n = ns[i];
+    params[i].parent->children[1].leaf->data.off_diagonal.s = ss[i];
+
+    params[i].parent->children[2].leaf = 
+      cr_malloc(sizeof(struct NodeOffDiagonal));
+    params[i].parent->children[2].leaf->data.off_diagonal.m = ns[i];
+    params[i].parent->children[2].leaf->data.off_diagonal.n = ms[i];
+    params[i].parent->children[2].leaf->data.off_diagonal.s = ss[i];
+    params[i].parent->children[2].leaf->data.off_diagonal.u =
+      cr_calloc(ns[i] * ss[i], sizeof(double));
+    params[i].parent->children[2].leaf->data.off_diagonal.v =
+      cr_calloc(ms[i] * ss[i], sizeof(double));
+    
+    params[i].offset = offsets[i];
+    params[i].len = lens[i];
+    params[i].vector = cr_calloc(lens[i], sizeof(double));
+    params[i].out = cr_calloc(lens[i], sizeof(double));
+    params[i].expected = cr_calloc(lens[i], sizeof(double));
+  }
+
+  // 0 HODLR x 10 vector
+  int i = 0;
+  strncat(params[i].hodlr_name, "0", STR_LEN);
+  strncat(params[i].vector_name, "10", STR_LEN);
+  fill_full_vector(lens[i], 10., params[i].vector);
+  strncat(params[i].out_name, "0", STR_LEN);
+  fill_full_vector(lens[i], 0., params[i].out);
+  fill_full_vector(lens[i], 0., params[i].expected);
+
+  // 5 HODLR x 0.5 vector
+  i++;
+  strncat(params[i].hodlr_name, "+/-5", STR_LEN);
+  fill_full_vector(ms[i] * ss[i], 5., 
+                   params[i].parent->children[1].leaf->data.off_diagonal.u);
+  fill_full_vector(ns[i] * ss[i], 1., 
+                   params[i].parent->children[1].leaf->data.off_diagonal.v);
+  fill_full_vector(ns[i] * ss[i], -5., 
+                   params[i].parent->children[2].leaf->data.off_diagonal.u);
+  fill_full_vector(ms[i] * ss[i], 1., 
+                   params[i].parent->children[2].leaf->data.off_diagonal.v);
+  strncat(params[i].vector_name, "0.5", STR_LEN);
+  fill_full_vector(lens[i], 0.5, params[i].vector);
+  strncat(params[i].out_name, "-10", STR_LEN);
+  fill_full_vector(lens[i], -10., params[i].out);
+  fill_full_vector(lens[i], -10., params[i].expected);
+  fill_full_vector(ms[i], 0., params[i].expected + params[i].offset);
+  fill_full_vector(ns[i], -20., 
+                   params[i].expected + params[i].offset + ms[i]);
+
+  // More realistic
+  i++;
+  strncat(params[i].hodlr_name, "L", STR_LEN);
+  params[i].parent->children[1].leaf->data.off_diagonal.u[ms[i]-1] = 1.;
+  params[i].parent->children[1].leaf->data.off_diagonal.v[0] = 1.;
+  params[i].parent->children[2].leaf->data.off_diagonal.u[0] = 1.;
+  params[i].parent->children[2].leaf->data.off_diagonal.v[ms[i]-1] = 1.;
+  strncat(params[i].vector_name, "3.14", STR_LEN);
+  fill_full_vector(lens[i], 3.14, params[i].vector);
+  strncat(params[i].out_name, "0..len", STR_LEN);
+  for (int j = 0; j < lens[i]; j++) {
+    params[i].out[j] = (double)j;
+    params[i].expected[j] = (double)j;
+  }
+  params[i].expected[offsets[i] + ms[i] - 1] += 3.14;
+  params[i].expected[offsets[i] + ms[i]] += 3.14;
+
+  if (i+1 != n_params) {
+    printf("PARAMETER SET-UP FAILED - allocated %d parameters but set %d\n",
+           n_params, i+1);
+  }
+
+  return cr_make_param_array(struct ParametersTestOffdiagxV, params, n_params, 
+                             free_ov_params);
+}
+
+
+ParameterizedTest(struct ParametersTestOffdiagxV *params, vector_algebra, 
+                  multiply_off_diagonal_vector) {
+  const int m = params->parent->children[1].leaf->data.off_diagonal.m;
+  const int n = params->parent->children[1].leaf->data.off_diagonal.n;
+  const int s = params->parent->children[1].leaf->data.off_diagonal.s;
+
+  cr_log_info("off-diag '%s' (m=%d, n=%d, s=%d) x vector '%s' (l=%d) + '%s'",
+              params->hodlr_name, m, n, s, params->vector_name, params->len,
+              params->out_name);
+
+  double *workspace = malloc(m * sizeof(double));
+
+  multiply_off_diagonal_vector(
+    params->parent, params->vector, params->out, workspace, 1, params->offset
+  );
+
+  expect_vector_double_eq_safe(params->out, params->expected, params->len, 
+                               params->len, 'V');
+
+  free(workspace);
+}
+
 

--- a/tests/src/test_vector_algebra.c
+++ b/tests/src/test_vector_algebra.c
@@ -2,6 +2,8 @@
 #define _TEST_HODLR 1
 #endif
 
+#include <stdio.h>
+
 #include <criterion/criterion.h>
 #include <criterion/parameterized.h>
 #include <criterion/new/assert.h>
@@ -14,11 +16,16 @@
 #include "../../src/vector_algebra.c"
 
 
+#define STR_LEN 10
+
+
 struct ParametersTestHxV {
   struct TreeHODLR *hodlr;
   double *vector;
   double *expected;
   int len;
+  char hodlr_name[STR_LEN];
+  char vector_name[STR_LEN];
 };
 
 
@@ -35,36 +42,40 @@ void free_hv_params(struct criterion_test_params *params) {
 }
 
 
-void laplacian_matrix(struct ParametersTestHxV *params,
-                      int start) {
-  int i = 0, ierr = 0, n_cases = 3, len = 21;
+int laplacian_matrix(struct ParametersTestHxV *params) {
+  int i = 0, ierr = 0;
+  const int n_cases = 3, len = 21, max_height = 3;
   double svd_threshold = 0.1;
   double *matrix = cr_malloc(len * len * sizeof(double));
 
-  for (int height = 1; height < 4; height++) {
-    i = n_cases * (height - 1) + start;
+  for (int height = 1; height < max_height+1; height++) {
+    i = n_cases * (height - 1);
 
     for (int j = i; j < i+n_cases; j++) {
       params[j].len = len;
       params[j].hodlr = allocate_tree_monolithic(height, &ierr, &cr_malloc, &cr_free);
     }
 
+    strncat(params[i].hodlr_name, "L", STR_LEN);
     fill_laplacian_matrix(len, matrix);
     dense_to_tree_hodlr(params[i].hodlr, params[i].len, NULL, 
                         matrix, svd_threshold, &ierr, &cr_malloc, &cr_free);
 
+    strncat(params[i+1].hodlr_name, "L0.5S", STR_LEN);
     fill_laplacian_matrix(len, matrix);
     matrix[params[i+1].len - 1] = 0.5;
     matrix[params[i+1].len * (params[i+1].len - 1)] = 0.5;
     dense_to_tree_hodlr(params[i+1].hodlr, params[i+1].len, NULL,
                         matrix, svd_threshold, &ierr, &cr_malloc, &cr_free);
 
+    strncat(params[i+2].hodlr_name, "L0.5A", STR_LEN);
     fill_laplacian_matrix(len, matrix);
     matrix[params[i+2].len - 1] = 0.5;
     dense_to_tree_hodlr(params[i+2].hodlr, params[i+2].len, NULL,
                         matrix, svd_threshold, &ierr, &cr_malloc, &cr_free);
 
     for (int j = 0; j < n_cases; j++) {
+      strncat(params[i+j].vector_name, "10", STR_LEN);
       params[i+j].vector = cr_malloc(params[i+j].len * sizeof(double));
       for (int k = 0; k < params[i+j].len; k++) {
         params[i+j].vector[k] = 10.;
@@ -82,20 +93,24 @@ void laplacian_matrix(struct ParametersTestHxV *params,
     params[i+2].expected[params[i+2].len - 1] = 15.;
   }
   cr_free(matrix);
+
+  return max_height * n_cases;
 }
 
 
-void identity_matrix(struct ParametersTestHxV *params) {
-  int i = 0, idx = 0, ierr = 0, n_cases = 3, len = 21;
+int identity_matrix(struct ParametersTestHxV *params) {
+  int i = 0, idx = 0, ierr = 0;
+  const int n_cases = 3, len = 21, max_height = 3;
   double svd_threshold = 0.1;
   double *matrix = cr_malloc(len * len * sizeof(double));
 
-  for (int height = 1; height < 4; height++) {
+  for (int height = 1; height < max_height+1; height++) {
     for (i = idx; i < idx+n_cases; i++) {
       params[i].len = len;
       params[i].hodlr = allocate_tree_monolithic(height, &ierr, 
                                                  &cr_malloc, &cr_free);
 
+      strncat(params[i].hodlr_name, "I", STR_LEN);
       fill_identity_matrix(len, matrix);
       dense_to_tree_hodlr(params[i].hodlr, len, NULL,
                           matrix, svd_threshold, &ierr, &cr_malloc, &cr_free);
@@ -103,52 +118,69 @@ void identity_matrix(struct ParametersTestHxV *params) {
       params[i].expected = cr_calloc(params[i].len, sizeof(double));
     }
 
+    strncat(params[idx].vector_name, "10", STR_LEN);
     for (int k = 0; k < params[idx].len; k++) {
       params[idx].vector[k] = 10.;
       params[idx].expected[k] = 10.;
     }
-    idx += 1;
+    idx++;
 
+    strncat(params[idx].vector_name, "0", STR_LEN);
     for (int k = 0; k < params[idx+1].len; k++) {
       params[idx].vector[k] = 0.;
       params[idx].expected[k] = 0.;
     }
-    idx+=1;
+    idx++;
 
+    strncat(params[idx].vector_name, "k..-10", STR_LEN);
     for (int k = 0; k < params[idx+2].len; k++) {
       params[idx].vector[k] = (double)(k - 10);
       params[idx].expected[k] = (double)(k - 10);
     }
-    idx+=1;
+    idx++;
   }
 
   cr_free(matrix);
+  return max_height * n_cases;
 }
 
 
 struct ParametersTestHxV * generate_hodlr_vector_params(int * len) {
-  int n_params = 9+9;
+  const int n_params = 9+9;
   *len = n_params;
   struct ParametersTestHxV *params = cr_malloc(n_params * sizeof(struct ParametersTestHxV));
 
-  laplacian_matrix(params, 0);
-  identity_matrix(params + 9);
+  int actual = laplacian_matrix(params);
+  actual += identity_matrix(params + actual);
+
+  if (actual != n_params) {
+    printf("PARAMETER SET-UP FAILED - allocated %d parameters but set %d\n",
+           n_params, actual);
+  }
+
   return params;
 }
 
 
-ParameterizedTestParameters(tree, test_hodlr_vector) {
+ParameterizedTestParameters(vector_algebra, test_hodlr_vector) {
   int n_params;
   struct ParametersTestHxV *params = generate_hodlr_vector_params(&n_params);
 
-  return cr_make_param_array(struct ParametersTestHxV, params, n_params, free_hv_params);
+  return cr_make_param_array(struct ParametersTestHxV, params, n_params, 
+                             free_hv_params);
 }
 
 
-ParameterizedTest(struct ParametersTestHxV *params, tree, test_hodlr_vector) {
+ParameterizedTest(struct ParametersTestHxV *params, vector_algebra, 
+                  test_hodlr_vector) {
+  cr_log_info("hodlr '%s' (height=%d, m=%d) x vector '%s' (l=%d)",
+              params->hodlr_name, params->hodlr->height, 
+              params->hodlr->root->m, params->vector_name, params->len);
+
   double * result = multiply_vector(params->hodlr, params->vector, NULL);
 
-  expect_vector_double_eq_safe(result, params->expected, params->len, params->len, 'V');
+  expect_vector_double_eq_safe(result, params->expected, params->len, 
+                               params->len, 'V');
 
   free(result);
 }


### PR DESCRIPTION
Couple improvements for the HODLR-Vector algebra implementation:

1. Remove unnecessary copies - use the `beta` parameter in `dgesdd` to add the results to the output directly
2. Remove no longer needed `workspace2`
3. Rewrite how offsets are handled in `multiply_off_diagonal_vector`
4. Add logging to tests
5. Add a couple tests for `multiply_off_diagonal_vector`