### PR TITLE
Rewrite documentation in numpydoc style

### DIFF
--- a/include/tree.h
+++ b/include/tree.h
@@ -318,14 +318,16 @@ double * multiply_hodlr_dense(const struct TreeHODLR *hodlr,
                               const int matrix_n,
                               const int matrix_ld,
                               double *out,
-                              const int out_ld);
+                              const int out_ld,
+                              int *ierr);
 
 double * multiply_hodlr_transpose_dense(const struct TreeHODLR *hodlr,
                                         const double *matrix,
                                         const int matrix_n,
                                         const int matrix_ld,
                                         double *out,
-                                        const int out_ld);
+                                        const int out_ld,
+                                        int *ierr);
 
 void multiply_internal_node_dense(
   const struct HODLRInternalNode *internal,
@@ -356,7 +358,8 @@ double * multiply_dense_hodlr(const struct TreeHODLR *hodlr,
                               const int matrix_m,
                               const int matrix_ld,
                               double * out,
-                              const int out_ld);
+                              const int out_ld,
+                              int *ierr);
  
 void compute_construct_tree_array_sizes(const int height,
                                         size_t *size_internal_nodes,

--- a/include/tree.h
+++ b/include/tree.h
@@ -257,7 +257,7 @@ struct TreeHODLR {
    * .. important::
    *
    *     This array may change even when this ``struct`` is passed as 
-   *     ``static``, since it is used as an internal workspace.
+   *     ``const``, since it is used as an internal workspace.
    */
   struct HODLRInternalNode **work_queue;
 

--- a/include/tree.h
+++ b/include/tree.h
@@ -293,7 +293,12 @@ void free_tree_data(struct TreeHODLR *hodlr);
 void free_tree_data(struct TreeHODLR *hodlr, void(*free)(void *ptr));
 #endif
 
-double * multiply_vector(const struct TreeHODLR *hodlr, const double *vector, double *out);
+double * multiply_vector(
+  const struct TreeHODLR *hodlr, 
+  const double *vector, 
+  double *out,
+  int *ierr
+);
 
 int multiply_hodlr_hodlr(
   const struct TreeHODLR *hodlr1,

--- a/src/allocators.c
+++ b/src/allocators.c
@@ -199,6 +199,13 @@ static inline void initialise_internal(
  *     Any partially allocated memory is automatically freed on failure and 
  *     ``NULL`` is returned.
  *
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``height < 1``.
+ * ALLOCATION_FAILURE
+ *     If any of the ``malloc`` calls fails.
+ *
  * Warnings
  * --------
  * The tree obtained from this function should only be passed into a function 
@@ -367,6 +374,13 @@ struct TreeHODLR* allocate_tree(const int height, int *ierr) {
  *     Any partially allocated memory is automatically freed on failure and 
  *     ``NULL`` is returned.
  *
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``height < 1``.
+ * ALLOCATION_FAILURE
+ *     If any of the ``malloc`` calls fails.
+ *
  * Warnings
  * --------
  * The tree obtained from this function should only be passed into a function 
@@ -393,6 +407,10 @@ struct TreeHODLR * allocate_tree_monolithic(const int height, int *ierr,
                                             void *(*malloc)(size_t size),
                                             void(*free)(void *ptr)) {
 #endif
+  if (height < 1) {
+    *ierr = INPUT_ERROR;
+    return NULL;
+  }
   size_t size_internal_nodes, size_leaf_nodes;
   size_t size_work_queue, size_innermost_leaves;
   *ierr = SUCCESS;

--- a/src/constructors.c
+++ b/src/constructors.c
@@ -11,21 +11,36 @@
  * size.
  *
  * Given a HODLR tree and the size of the matrix (number of rows), iterates 
- * over the entire tree and computes the size of each diagonal HODLR block
- * represented by a :c:struct:`HODLRInternalNode`. Saves each size on the 
- * appropriate node.
+ * over the entire tree and computes the size of each node's dimensions (``m``
+ * and ``n`` as appropriate) by halving the parent's block size. The results 
+ * are saved on the ``hodlr``.
  *
- * :param hodlr: The HODLR tree whose block sizes to compute. Must be a 
- *               correctly allocated tree and should be empty - any data on 
- *               the tree may be overwritten. Must not be NULL; otherwise is
- *               undefined.
- * :param m: The number of rows of the full HODLR matrix.
+ * Sets the block sizes for all nodes - internal nodes, diagonal leaf nodes,
+ * and off-diagonal leaf nodes, but does not set the ranks (``s``) for the
+ * off-diagonal leaf nodes.
  *
- * :return: A pointer to access an array of internal nodes which contains 
- *          the innermost internal nodes on ``hodlr``.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR tree whose block sizes to set. Must be a 
+ *     correctly allocated tree but should be empty - any data on the tree may 
+ *     be overwritten. Must not be ``NULL``.
+ * m
+ *     The number of rows of the full HODLR matrix.
+ *
+ * Returns
+ * -------
+ * struct HODLRInternalNode **
+ *     Pointer representing an array of pointers to internal nodes. This is
+ *     the :c:member:`TreeHODLR.work_queue` but populated with the innermost 
+ *     internal nodes on ``hodlr``.
+ *
+ * See Also
+ * --------
+ * compute_block_sizes_custom : Uses the sizes of the diagonal blocks.
  */
 static struct HODLRInternalNode ** compute_block_sizes_halves(
-  struct TreeHODLR *restrict hodlr,
+  struct TreeHODLR *restrict const hodlr,
   const int m
 ) {
   struct HODLRInternalNode **queue = hodlr->work_queue;
@@ -85,22 +100,37 @@ static struct HODLRInternalNode ** compute_block_sizes_halves(
  * Given a HODLR tree and the size (number of rows) of each dense block of the
  * matrix (the innermost diagonal blocks, i.e. 
  * :c:param:`TreeHODLR.innermost_leaves`), iterates over the entire tree and 
- * computes the size of each diagonal HODLR block node. Saves each size on the 
- * appropriate node.
+ * computes the size of each node's dimensions by summing the two children's
+ * block sizes (or looking at the siblings' block sizes as appropriate). The 
+ * results are saved on the ``hodlr``.
  *
- * :param hodlr: Pointer to the HODLR tree whose block sizes to compute. Must 
- *               be a correctly allocated tree and should be empty - any data 
- *               on the tree may be overwritten. Must not be NULL; otherwise 
- *               is undefined.
- * :param ms: Pointer to access an array containing the number of rows of each 
- *            :c:struct:`NodeDiagonal` that will make up the HODLR tree.
+ * Sets the block sizes for all nodes - internal nodes, diagonal leaf nodes,
+ * and off-diagonal leaf nodes, but does not set the ranks (``s``) for the
+ * off-diagonal leaf nodes.
  *
- * :return: A pointer to access an array of internal nodes which contains 
- *          the innermost internal nodes on ``hodlr``.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR tree whose block sizes to set. Must be a 
+ *     correctly allocated tree but should be empty - any data on the tree may 
+ *     be overwritten. Must not be ``NULL``.
+ * m
+ *     The number of rows of the full HODLR matrix.
+ *
+ * Returns
+ * -------
+ * struct HODLRInternalNode **
+ *     Pointer representing an array of pointers to internal nodes. This is
+ *     the :c:member:`TreeHODLR.work_queue` but populated with the innermost 
+ *     internal nodes on ``hodlr``.
+ *
+ * See Also
+ * --------
+ * compute_block_sizes_halves : Uses the size of the full matrix.
  */
 static struct HODLRInternalNode ** compute_block_sizes_custom(
-  struct TreeHODLR *hodlr,
-  const int *ms
+  struct TreeHODLR *restrict const hodlr,
+  const int *restrict const ms
 ) {
   struct HODLRInternalNode **queue = hodlr->work_queue;
   long n_parent_nodes = hodlr->len_work_queue;
@@ -149,33 +179,44 @@ static struct HODLRInternalNode ** compute_block_sizes_custom(
  *
  * Given a dense matrix and an array of the innermost (higest depth) internal
  * nodes of a HODLR tree, copies the appropriate data from the dense matrix 
- * into data array (:c:member:`NodeDiagonal.data`) of each node's two diagonal
- * children.
+ * into the data array (:c:member:`NodeDiagonal.data`) of each node's two 
+ * diagonal children.
  *
- * :param matrix: Pointer to the array holding the dense matrix from which to 
- *                copy data. Must be an ``m`` x ``m`` square 2D column-major 
- *                matrix. Must not be NULL; otherwise is undefined.
- * :param matrix_ld: The number of rows and columns of ``matrix``.
- * :param queue: Pointer to an array of internal nodes. Must be of length 
- *               ``len_queue`` and fully filled by the lowest-level internal
- *               nodes.
- * :param len_queue: The length of the ``len_queue`` array.
- * :param ierr: Error code corresponding to :c:enum:`ErrorCode`. On 
- *              successful completion of the function, 
- *              :c:enum:`ErrorCode.SUCCESS` is returned. Otherwise,
- *              a corresponding error code is set.
- *              Must NOT be ``NULL`` pointer - passing in ``NULL``
- *              as ``ierr`` is undefined behaviour.
+ * Parameters
+ * ----------
+ * matrix
+ *     Pointer representing an array holding the dense matrix from which to 
+ *     copy data. Must be an ``matrix_ld`` x ``matrix_ld`` square 2D 
+ *     column-major matrix. Must not be ``NULL``.
+ * matrix_ld
+ *     The number of rows and columns of ``matrix``.
+ * queue
+ *     Pointer representing an array of pointers to internal nodes. Must be 
+ *     of length ``len_queue`` and fully filled by the lowest-level internal
+ *     nodes (i.e. the parents of :c:member:`TreeHODLR.innermost_leaves`).
+ * len_queue
+ *     The length of the ``len_queue`` array.
+ * ierr
+ *     Pointer to an integer used to signal the success or failure of this 
+ *     function. An error status code from :c:enum:`ErrorCode` is written into 
+ *     the pointer **if an error occurs**. Must not be ``NULL`` - doing so is 
+ *     undefined.
+ *
+ * Errors
+ * ------
+ * ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls fails. 
  */
-static void copy_diagonal_blocks(double *restrict matrix,
-                                 int matrix_ld,
-                                 struct HODLRInternalNode **restrict queue,
-                                 long len_queue,
-                                 int *restrict ierr
+static inline void copy_diagonal_blocks(
+  const double *restrict const matrix,
+  const int matrix_ld,
+  struct HODLRInternalNode *restrict const *restrict queue,
+  const long len_queue,
+  int *restrict const ierr
 #ifdef _TEST_HODLR
-                                 , void *(*malloc)(size_t size)
+  , void *(*malloc)(size_t size)
 #endif
-                                 ) {
+) {
   int offset = 0;
 
   for (int parent = 0; parent < len_queue; parent++) {
@@ -201,73 +242,91 @@ static void copy_diagonal_blocks(double *restrict matrix,
 
 
 /**
- * Compresses a dense off-diagonal block.
+ * Compresses a single block of a matrix into an off-diagonal node using SVD.
  *
- * Internal function that computes the SVD of a matrix block
- * and saves the the significant parts of the U and V matrices
- * on a off-diagonal node.
+ * Computes the SVD of a dense matrix block and saves the significant parts of
+ * the U and V matrices of an off-diagonal leaf node.
  *
- * :param node: The node to which to save the results. Must have its ``m`` and
- *              ``n`` values set.
- * :param n_singular_values: The number of singular values returned
- *                           by the compact SVD. I.e. the smaller
- *                           value between ``m`` and ``n``.
- * :param matrix_leading_dim: The number of rows of the full matrix
- *                            ``lapack_matrix`` (lda). 
- *                            ``matrix_leading_dim`` >= ``m``.
- * :param lapack_matrix: A pointer to a column-major array containing
- *                       the 2D matrix to compress. This may be a 
- *                       subset of a larger matrix. Might be 
- *                       overwritten by the SVD routine.
- * :param s: Pointer to an array used to store all the singular values
- *           of ``lapack_matrix``. A 1D aray of size of at least
- *           ``n_singular_values``.
- * :param u: Pointer to an array used to temporarily store all the 
- *           columns of the U matrix of the ``lapack_matrix``. 
- *           A 2D array of size of at least ``m`` x 
- *           ``n_singular_values``.
- * :param vt: Pointer to an array used to temporarily store all the
- *            rows of the VT matrix of the ``lapack_matrix``.
- *            A 2D array of size of at least ``n_singular_values``
- *            x ``n``.
- * :param svd_threshold: The threshold for discarding singular values. 
- *                       Any singular values (and the corresponding 
- *                       column vectors of the U and V matrices) that 
- *                       satisfy :math:`s_i < t * s_0` will be 
- *                       discarded (:math:`s_i` is i-th singular value, 
- *                       :math:`t` is the ``svd_threshold``, and 
- *                       :math:`s_0` is the largest singular value).
- * :param ierr: Error code corresponding to :c:enum:`ErrorCode`. On 
- *              successful completion of the function, 
- *              :c:enum:`ErrorCode.SUCCESS` is returned. Otherwise,
- *              a corresponding error code is set.
- *              Must NOT be ``NULL`` pointer - passing in ``NULL``
- *              as ``ierr`` is undefined behaviour.
- * :return: The return code from the SVD routine.
+ * Parameters
+ * ----------
+ * node
+ *     The node on which to save the results. Must be allocated and have its 
+ *     ``m`` and ``n`` values set. However, the ``u``, ``v``, and ``s`` fields
+ *     should be empty as they will be overwritten.
+ * m_smaller
+ *     The smaller value between ``node->m`` and ``node->n``.
+ * matrix_ld
+ *     Leading dimension of ``lapack_matrix`` - he number of rows of the full 
+ *     matrix must be greater than or equal to ``m_smaller``.
+ * lapack_matrix
+ *     Pointer representing an array containing the column-major 2D matrix to 
+ *     compress. This may be a subset of a larger matrix - in this the 
+ *     compressed block is ``lapack_matrix[:node->m, :node->n]``, i.e. values
+ *     starting from the beginning of the passed-in array will be used and
+ *     ``matrix_ld`` will be used to traverse the full matrix. 
+ *     Might be overwritten by the SVD routine.
+ * s
+ *     Pointer representing an array used to temporarily store all the 
+ *     singular values of ``lapack_matrix``. Must be a 1D aray of size of at 
+ *     least ``m_smaller``.
+ * u
+ *     Pointer representing an array used to temporarily store the full U
+ *     matrix. Must be of size of at least ``node->m`` x ``m_smaller``.
+ * vt
+ *     Pointer representing an array used to temporarily store the full
+ *     :math:`V^T` matrix. Must be of size of at least ``m_smaller``  x 
+ *     ``node->n``.
+ * svd_threshold
+ *     The threshold for discarding singular values after the SVD. Any 
+ *     singular values smaller than one ``svd_threshold``-th of the first 
+ *     singular value will be treated as approximately zero and therefore 
+ *     the corresponding column vectors of the :math:`U` and :math:`V` 
+ *     matrices will be discarded.
+ * ierr
+ *     Pointer to an integer hodling the :c:member:`ErrorCode.SUCCESS` value. 
+ *     Used to signal the success or failure of this function. An error status 
+ *     code from :c:enum:`ErrorCode` is written into the pointer 
+ *     **if an error occurs**. Must not be ``NULL`` - doing so is undefined.
+ *
+ * Returns
+ * -------
+ * int
+ *     The return code from the ``dgesdd`` routine.
+ *
+ * Errors
+ * ------
+ * ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in this function fails.
+ * SVD_ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in the :c:func:`svd_double` function
+ *     fails.
+ * SVD_FAILURE
+ *     If the ``dgesdd`` routine fails.
  */
-static int compress_off_diagonal(struct NodeOffDiagonal *restrict node,
-                                 const int n_singular_values,
-                                 const int matrix_leading_dim,
-                                 double *restrict lapack_matrix,
-                                 double *restrict s,
-                                 double *restrict u,
-                                 double *restrict vt,
-                                 const double svd_threshold,
-                                 int *restrict ierr
+static inline int compress_off_diagonal(
+  struct NodeOffDiagonal *restrict const node,
+  const int m_smaller,
+  const int matrix_ld,
+  double *restrict const lapack_matrix,
+  double *restrict const s,
+  double *restrict const u,
+  double *restrict const vt,
+  const double svd_threshold,
+  int *restrict const ierr
 #ifdef _TEST_HODLR
-                                 , void *(*malloc)(size_t size)
+  , void *(*malloc)(size_t size)
 #endif
-                                 ) {
+) {
   const int m = node->m, n = node->n;
-  int result = svd_double(m, n, n_singular_values, matrix_leading_dim, 
-                          lapack_matrix, s, u, vt, ierr);
+  int result = 
+    svd_double(m, n, m_smaller, matrix_ld, lapack_matrix, s, u, vt, ierr);
   if (*ierr != SUCCESS) {
     return result;
   }
 
   int svd_cutoff_idx = 1;
   if (s[0] > svd_threshold) {
-    for (svd_cutoff_idx=1; svd_cutoff_idx < n_singular_values; svd_cutoff_idx++) {
+    for (svd_cutoff_idx=1; svd_cutoff_idx < m_smaller; svd_cutoff_idx++) {
       if (s[svd_cutoff_idx] < svd_threshold * s[0]) {
         break;
       }
@@ -294,7 +353,7 @@ static int compress_off_diagonal(struct NodeOffDiagonal *restrict node,
   }
   for (int i=0; i<svd_cutoff_idx; i++) {
     for (int j=0; j<n; j++) {
-      v_store[j + i * n] = vt[i + j * n_singular_values];
+      v_store[j + i * n] = vt[i + j * m_smaller];
     }
   }
 
@@ -306,13 +365,12 @@ static int compress_off_diagonal(struct NodeOffDiagonal *restrict node,
 }
 
 
-#include <stdio.h>
 /**
- * Compresses a dense matrix into the HODLR format.
+ * Compresses an entire dense matrix into the HODLR format using SVD.
  *
  * Given a HODLR tree and a dense matrix, iteratively compresses the matrix 
- * into the pre-allocated HODLR tree by looping bottom-up starting with the 
- * bottom-most internal nodes in ``queue``.
+ * into the pre-allocated HODLR tree by compressing each block of the matrix 
+ * into an off-diagona leaf node.
  *
  * This function contains OpenMP pragmas that schedule tasks - it assumes that
  * the function is being run from:
@@ -323,53 +381,85 @@ static int compress_off_diagonal(struct NodeOffDiagonal *restrict node,
  *    #pragma omp single
  *    #pragma omp taskgroup
  *
- * :param hodlr: The tree HODLR to which to compress the ``matrix``. This tree
- *               must be fully and correctly allocated, and the sizes of the
- *               internal nodes (i.e. :c:member:`HODLRInternalNode.m`) must 
- *               already be set.
- * :param queue: An array of pointers to internal nodes. Must be fully filled
- *               with all the lowest-level internal nodes of ``hodlr``.
- * :param matrix: Pointer to the array holding the dense matrix from which to 
- *                copy data. Must be an ``m`` x ``m`` square 2D column-major 
- *                matrix. Must not be NULL; otherwise is undefined.
- * :param m: The size the full ``matrix``.
- * :param s: Workspace for the SVD singular values. Must be large enough to 
- *           accomodate all the singular values for all HODLR compressions,
- *           i.e. be at least of size ``4 * floor(m / 2)``. NULL leads to 
- *           undefined behaviour.
- * :param u: Workspace for the SVD U matrices. Must be large enough to 
- *           accomodate all the U matrices for all HODLR compressions,
- *           i.e. be at least of size ``4 * floor(m / 2) * ceil(m / 2)``. NULL
- *           leads to undefined behaviour.
- * :param vt: Workspace for the SVD V^T matrices. Must be large enoug to 
- *            accomodate all the V^T matrices for all HODLR compressions, i.e.
- *            be at least of size ``4 * floor(m / 2) * ceil(m / 2)``. NULL 
- *            leads to undefined behaviour.
- * :param svd_threshold: The threshold for discarding singular values. Any 
- *                       singular values (and the corresponding column vectors 
- *                       of the U and V matrices) that satisfy 
- *                       :math:`s_i < t * s_0` will be discarded (:math:`s_i` 
- *                       is i-th singular value, :math:`t` is the 
- *                       ``svd_threshold``, and :math:`s_0` is the largest 
- *                       singular value).
- * :param ierr: Error code corresponding to :c:enum:`ErrorCode`. On any 
- *              failure, a corresponding error code is written to the pointer,
- *              but ``SUCCESS`` is not written here. NULL is undefined 
- *              behaviour.
+ * If any failure occurs, the function exits early without cleaning up, 
+ * setting ``ierr`` and returning an error code. When running with OpenMP,
+ * an immediate abort is performed if cancelling is turned on, otherwise the
+ * remaining work runs to completion.
+ *
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR into which to compress the ``matrix``. This tree
+ *     must be fully and correctly allocated, and the block sizes of all nodes
+ *     must already be set. However, all other data fields should be empty as
+ *     they will be overwritten.
+ * queue
+ *     Pointer representing an array of pointers to internal nodes. Must be 
+ *     fully filled with all the lowest-level internal nodes of ``hodlr`` 
+ *     (i.e. the parents of :c:member:`TreeHODLR.innermost_leaves`). Must not
+ *     be ``NULL``.
+ * matrix
+ *     Pointer representing an array holding the dense matrix to compress. 
+ *     Must be an ``m`` x ``m`` square 2D column-major matrix. Must not be 
+ *     ``NULL``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * s
+ *     Pointer representing array used as a workspace for storing the SVD 
+ *     singular values. Must be large enough to accomodate all the singular 
+ *     values for all HODLR compressions in parallel, i.e. be at least of size 
+ *     ``4 * floor(matrix_ld / 2)``. Must not be ``NULL``.
+ * u
+ *     Pointer representing an array used as a workspace for storing the SVD U 
+ *     matrices. Must be large enough to ccomodate all the U matrices for all 
+ *     HODLR compressions, i.e. be at least of size 
+ *     ``4 * floor(m / 2) * ceil(m / 2)``. Must noe be ``NULL``.
+ * vt
+ *     Pointer representing an array used as a workspace for storing the SVD 
+ *     :math:`V^T` matrices. Must be large enoug to accomodate all the 
+ *     :math:`V^T` matrices for all HODLR compressions, i.e. be at least of 
+ *     size ``4 * floor(m / 2) * ceil(m / 2)``. Must not be ``NULL``.
+ * svd_threshold
+ *     The threshold for discarding singular values after the SVD. Any 
+ *     singular values smaller than one ``svd_threshold``-th of the first 
+ *     singular value will be treated as approximately zero and therefore 
+ *     the corresponding column vectors of the :math:`U` and :math:`V` 
+ *     matrices will be discarded.
+ * ierr
+ *     Pointer to an integer hodling the :c:member:`ErrorCode.SUCCESS` value. 
+ *     Used to signal the success or failure of this function. An error status 
+ *     code from :c:enum:`ErrorCode` is written into the pointer 
+ *     **if an error occurs**. Must not be ``NULL`` - doing so is undefined.
+ *
+ * Returns
+ * -------
+ * int
+ *     The return code from the ``dgesdd`` routine.
+ *
+ * Errors
+ * ------
+ * ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in this function fails.
+ * SVD_ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in the :c:func:`svd_double` function
+ *     fails.
+ * SVD_FAILURE
+ *     If the ``dgesdd`` routine fails.
  */
-static int compress_matrix(struct TreeHODLR *restrict hodlr,
-                           struct HODLRInternalNode **restrict queue,
-                           double *restrict matrix,
-                           const int matrix_ld,
-                           double *restrict s,
-                           double *restrict u,
-                           double *restrict vt,
-                           const double svd_threshold,
-                           int *ierr
+static inline int compress_matrix(
+  struct TreeHODLR *restrict const hodlr,
+  struct HODLRInternalNode *restrict *restrict queue,
+  double *restrict const matrix,
+  const int matrix_ld,
+  double *restrict const s,
+  double *restrict const u,
+  double *restrict const vt,
+  const double svd_threshold,
+  int *restrict const ierr
 #ifdef _TEST_HODLR
-                           , void *(*malloc)(size_t size)
+  , void *(*malloc)(size_t size)
 #endif
-                           ) {
+) {
   long n_parent_nodes = hodlr->len_work_queue;
   int offset_matrix = 0, offset_s = 0, offset_u = 0;
   struct NodeOffDiagonal *node = NULL;
@@ -457,71 +547,97 @@ static int compress_matrix(struct TreeHODLR *restrict hodlr,
 
 
 /**
- * Compresses a dense matrix into a HODLR tree matrix.
+ * Compresses a dense matrix into the HODLR format.
  *
- * Requires a preallocated HODLR tree (e.g. from 
- * :c:func:`allocate_tree`), a matrix, and some settings.
+ * Given an empty HODLR tree and a dense matrix, fills in the HODLR by 
+ * compressing the off-diagonal blocks using SVD.
  *
- * :param hodlr: A pointer to a HODLR tree. This *should* be an empty tree, 
- *               with no data filled in, since any pointers to data will be 
- *               overwritten with newly allocated data and therefore lost, 
- *               potentially causing memory leaks.
- *               If ``NULL``, aborts immediately. Passing in a partially or 
- *               incorrectly allocated tree is an undefined behaviour.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to a HODLR into which to compress ``matrix``. 
+ *     Must be a fully allocated HODLR tree. Passing in a partially or 
+ *     incorrectly allocated tree leads to undefined behaviour.
+ *     *Should* be empty, with no data filled in, since all data will be 
+ *     overwritten, potentially causing memory leaks.
+ *     If ``NULL``, aborts immediately.
+ * m
+ *     The size of the ``matrix`` matrix. I.e., the number of rows and columns
+ * ms
+ *     (optional) Pointer representing an array containing the sizes of the 
+ *     dense diagonal blocks to use for ``hodlr``. If provided, this allows 
+ *     the HODLR tree to be split into blocks of custom sizes. If ``NULL``, 
+ *     this parameter is ignored and the HODLR is split in halves.
+ *     If provided, this must be an array of length :math:`2^h` where ``h`` is 
+ *     the height of ``hodlr`` whose values add up to ``m``. A shorter array 
+ *     leads to undefined behaviour. Each entry in the array must specify the 
+ *     size of a dense diagonal block, starting with the one in the top left 
+ *     corner (i.e. ``matrix[0]``).
+ * matrix
+ *     Pointer representing an array storing the dense matrix to compress. 
+ *     This must be a square column-major 2D matrix of size ``m`` x ``m``.
+ *     If ``NULL``, aborts immediately
+ *     *Some of the values may be overwritten during SVD compuration.*
+ * svd_threshold
+ *     The threshold for discarding singular values after the SVD. Any 
+ *     singular values smaller than one ``svd_threshold``-th of the first 
+ *     singular value will be treated as approximately zero and therefore 
+ *     the corresponding column vectors of the :math:`U` and :math:`V` 
+ *     matrices will be discarded.
+ * ierr
+ *     Pointer to an integer hodling used to signal the success or failure of 
+ *     this function. An status code from :c:enum:`ErrorCode` is written into 
+ *     the pointer. Must not be ``NULL`` - doing so is undefined.
  *
- * :param m: The size of the ``matrix`` matrix. I.e., the number of rows and 
- *           columns.
+ * Returns
+ * -------
+ * int
+ *     The error code from the SVD routine.
  *
- * :param ms: (optional) A pointer to access an array containing the sizes 
- *            of the dense diagonal blocks. This allows the HODLR tree to be 
- *            split in a customised fashion. If ``NULL``, this parameter is 
- *            ignored and the HODLR is split in halves.
- *            If provided, this must be an array of length :math:`2^h` where
- *            ``h`` is the height of ``hodlr`` (shorter array leads to 
- *            undefined behaviour). Each entry in the array must specify the 
- *            size of a dense diagonal block, starting with the one in the 
- *            top left corner (i.e. ``matrix[0]``).
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``hodlr`` or ``matrix`` is ``NULL`` or if ``ms`` does not match 
+ *     ``m``.
+ * ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in this function fails.
+ * SVD_ALLOCATION_FAILURE
+ *     If one of the ``malloc`` calls in the :c:func:`svd_double` function
+ *     fails.
+ * SVD_FAILURE
+ *     If the ``dgesdd`` routine fails.
  *
- * :param matrix: The dense matrix to compress. This must be an column-major 
- *                array holding an ``m`` x ``m`` square 2D matrix.
- *                If ``NULL``, aborts immediately *Some of the values may be 
- *                overwritten during SVD compuration*
+ * Warnings
+ * --------
+ * If anything fails for any reason, the routine immediately aborts, setting
+ * ``ierr`` and returning an error code as appropriate. No clean-up is 
+ * performed, so it is likely that the data will be partially allocated. If 
+ * that is the case, it must be freed (e.g. using :c:func:`free_tree_data`) 
+ * before attempting to use this function again to avoid memory leaks.
  *
- * :param svd_threshold: The threshold for discarding singular values. Any 
- *                       singular values (and the corresponding column vectors 
- *                       of the U and V matrices) that satisfy 
- *                       :math:`s_i < t * s_0` will be discarded (:math:`s_i` 
- *                       is i-th singular value, :math:`t` is the 
- *                       ``svd_threshold``, and :math:`s_0` is the largest 
- *                       singular value).
+ * See Also
+ * --------
+ * allocate_tree : Used for allocating the tree structure
  *
- * :param ierr: Error code corresponding to :c:enum:`ErrorCode`. On successful 
- *              completion of the function, :c:enum:`ErrorCode.SUCCESS` is 
- *              returned. Otherwise, a corresponding error code is set.
- *              Must NOT be ``NULL`` pointer - passing in ``NULL`` as ``ierr`` 
- *              is undefined behaviour.
- *
- * :return: The error code from the SVD routine.
- *
- * .. warning::
- *
- *     No clean-up is performed if the compression fails for any 
- *     reason. Therefore, it is likely that the data will be 
- *     partially allocated. If that is the case, it must be 
- *     freed (e.g. using :c:func:`free_tree_data`) before attempting
- *     to use this function again to avoid memory leaks.
+ * Notes
+ * -----
+ * The compression is performed by first determining the size of each block of
+ * the matrix, then copying the diagonal blocks into new, small dense arrays,
+ * and lastly compressing each off-diagonal block using SVD and storing a 
+ * number of columns of the U and V matrices obtained from SVD.
  */
-int dense_to_tree_hodlr(struct TreeHODLR *restrict hodlr, 
-                        const int m,
-                        const int *restrict const ms,
-                        double *restrict matrix, 
-                        const double svd_threshold,
-                        int *ierr
+int dense_to_tree_hodlr(
+  struct TreeHODLR *restrict const hodlr, 
+  const int m,
+  const int *restrict const ms,
+  double *restrict const matrix, 
+  const double svd_threshold,
+  int *restrict const ierr
 #ifdef _TEST_HODLR
-                        , void *(*malloc)(size_t size),
-                        void(*free)(void *ptr)
+  , void *(*malloc)(size_t size),
+  void(*free)(void *ptr)
 #endif
-                        ) {
+) {
   if (hodlr == NULL || matrix == NULL) {
     *ierr = INPUT_ERROR;
     return 0;

--- a/src/dense_algebra.c
+++ b/src/dense_algebra.c
@@ -350,6 +350,12 @@ static inline int multiply_off_diagonal_transpose_dense(
  *     point to the same memory location.
  * ALLOCATION_FAILURE
  *     If ``out == NULL`` and its allocation fails.
+ *
+ * See Also
+ * --------
+ * multiply_hodlr_transpose_dense : Performs a transpose.
+ * multiply_dense_hodlr : Other side of multiplication.
+ * multiply_internal_node_dense : Uses internal node instead of HODLR struct.
  */
 double * multiply_hodlr_dense(
   const struct TreeHODLR *restrict const hodlr,
@@ -475,6 +481,12 @@ double * multiply_hodlr_dense(
  *     array. Must be greater than or equal to the number of rows of 
  *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
  *     allocated with size ``out_ld`` x ``matrix_n``.
+ *
+ * See Also
+ * --------
+ * multiply_hodlr_dense : Uses HODLR struct instead of internal node.
+ * multiply_internal_node_transpose_dense : Performs transpose.
+ * multiply_dense_internal_node : Other side of multiplication.
  */
 void multiply_internal_node_dense(
   const struct HODLRInternalNode *restrict const internal,
@@ -595,6 +607,11 @@ void multiply_internal_node_dense(
  *     point to the same memory location.
  * ALLOCATION_FAILURE
  *     If ``out == NULL`` and its allocation fails.
+ *
+ * See Also
+ * --------
+ * multiply_hodlr_dense : Does not transpose.
+ * multiply_internal_node_transpose_dense : Uses internal node not HODLR struct.
  */
 double * multiply_hodlr_transpose_dense(
   const struct TreeHODLR *restrict const hodlr,
@@ -683,6 +700,11 @@ double * multiply_hodlr_transpose_dense(
  *     array. Must be greater than or equal to the number of rows of 
  *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
  *     allocated with size ``out_ld`` x ``matrix_n``.
+ *
+ * See Also
+ * --------
+ * multiply_hodlr_transpose_dense : Uses HODLR struct instead of internal node.
+ * multiply_internal_node_dense : Does not transpose.
  */
 void multiply_internal_node_transpose_dense(
   const struct HODLRInternalNode *restrict const internal,
@@ -925,6 +947,11 @@ static inline int multiply_dense_off_diagonal(
  *     point to the same memory location.
  * ALLOCATION_FAILURE
  *     If ``out == NULL`` and its allocation fails.
+ *
+ * See Also
+ * --------
+ * multiply_hodlr_dense : Other side of multiplication.
+ * multiply_dense_internal_node : Uses an internal node instead of HODLR struct.
  */
 double * multiply_dense_hodlr(
   const struct TreeHODLR *restrict const hodlr,
@@ -999,7 +1026,7 @@ double * multiply_dense_hodlr(
 
 
 /**
- * Multiplies a dense matryx by a HODLR matrix represented by an internal 
+ * Multiplies a dense matrix by a HODLR matrix represented by an internal 
  * node.
  *
  * Given a dense matrix, and an internal node and its height, computes their
@@ -1050,6 +1077,11 @@ double * multiply_dense_hodlr(
  *     array. Must be greater than or equal to ``matrix_m``, even if 
  *     ``out == NULL``, in which case ``out`` will be allocated with size 
  *     ``out_ld`` x M.
+ *
+ * See Also
+ * --------
+ * multiply_dense_hodlr : Takes a HODLR struct instead of internal node.
+ * multiply_internal_node_dense : Other side of multiplication.
  */
 void multiply_dense_internal_node(
   const struct HODLRInternalNode *restrict const internal,

--- a/src/dense_algebra.c
+++ b/src/dense_algebra.c
@@ -3,77 +3,89 @@
 
 #include "../include/lapack_wrapper.h"
 #include "../include/tree.h"
+#include "../include/error.h"
 #include "../include/utils.h"
 #include "../include/blas_wrapper.h"
 
 
 /**
- * Computes the workspace size(s) required for the HODLR-dense multiplication
+ * Computes the workspace size required for the HODLR-dense multiplication
  * functions.
  *
  * Given a HODLR tree and the non-shared dimension of the dense matrix, 
- * computes the minimum lengths of the two workspace arrays used by the 
+ * computes the minimum length of the workspace array used by the 
  * :c:func:`multiply_hodlr_dense` and :c:func:`multiply_dense_hodlr` functions
  * when running with that HODLR tree.
  *
- * :param hodlr: Pointer to a HODLR tree for which to compute the workspace 
- *               sizes. Must not be ``NULL`` and must be filled with data, 
- *               otherwise is undefined behaviour.
- * :param matrix_a: The non-shared dimension of the dense matrix, i.e. the 
- *                  number of columns for :c:func:`multiply_hodlr_dense` or
- *                  the number of rows for :c:func:`multiply_dense_hodlr`, for 
- *                  which to compute the workspace sizes. Must be greater than 
- *                  0, other values are undefined behaviour.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR for which to compute the workspace size. Must not 
+ *     be ``NULL`` and must be a fully constructed tree occupied by data - 
+ *     anything else will result in undefined behaviour.
+ * matrix_a
+ *     The non-shared dimension of the dense matrix, i.e. the number of 
+ *     columns for :c:func:`multiply_hodlr_dense` or the number of rows for 
+ *     :c:func:`multiply_dense_hodlr`, for which to compute the workspace 
+ *     sizes. Must be greater than 0, other values are undefined behaviour.
+ *
+ * Returns
+ * -------
+ * int
+ *     The number of elements that the workspace array will require for the
+ *     multiplication of the two matrices.
  */
 int compute_multiply_hodlr_dense_workspace(
   const struct TreeHODLR *restrict const hodlr,
   const int matrix_a
 ) {
-  int s = 0, idx = 0;
-  long n_parent_nodes = hodlr->len_work_queue;
-
-  struct HODLRInternalNode **queue = hodlr->work_queue;
-
-  int highest_s = get_highest_s(hodlr);
-
-  return highest_s * matrix_a;
+  return get_highest_s(hodlr) * matrix_a;
 }
 
 
 /**
  * Multiplies a low-rank matrix and a dense matrix.
  *
- * Given an off-diagonal node (which represents a low-rank matrix) and a 
+ * Given an off-diagonal leaf node (which represents a low-rank matrix) and a 
  * dense matrix, computes the product of the two as a dense matrix.
  *
- * :param node: A pointer to the off-diagonal node to multiply. It must not be
- *              ``NULL`` and must point to a valid node with correctly 
- *              allocated and set values, anything else is undefined.
- * :param matrix: A pointer to an array containing the dense matrix to be used
- *                for the multiplication. Must not be ``NULL``. Must not 
- *                overlap with any other pointers.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param beta2: The value of ``beta`` to use for the final ``dgesdd``.
- *               Determines whether results overwrite ``out`` or are added.
- * :param workspace: A pointer to a workspace array to be used. Must be large
- *                   enough to accomodate a ``s`` x ``matrix_n`` matrix where
- *                   ``s`` is the number of stored singular values on 
- *                   ``node``. Must not overlap with any other pointers.
- * :param out: A pointer to an array to which to store the result. Must be 
- *             large enough to accomodate a ``m`` x ``matrix_n`` matrix, where
- *             ``m`` is the number of rows of ``node``. Must not overlap with
- *             any other pointers.
- * :param out_ld: The leading dimension of ``out``.
+ * Parameters
+ * ----------
+ * node
+ *     Pointer to the off-diagonal node to multiply. Must not be ``NULL``. 
+ *     Must point to a valid node with data allocated and set.
+ * matrix
+ *     Pointer representing an array containing the dense matrix to be 
+ *     multiplied. Must not be ``NULL``. Must not overlap with ``workspace``
+ *     or ``out``.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * beta2
+ *     The value of ``beta`` to use for the final ``dgesdd``. Determines 
+ *     whether results overwrite ``out`` or are added.
+ * workspace
+ *     Pointer representing a workspace array available for storing 
+ *     intermediate results. Must be of size at least ``node->s`` x 
+ *     ``matrix_n``. Must not overlap with ``matrix`` or ``out``. Must not be
+ *     ``NULL``.
+ * out
+ *     Pointer representing an array to which to store the result. Must be of
+ *     size at least ``m`` x ``matrix_n`` matrix, where ``m`` is the number of 
+ *     rows of ``node``. Must not overlap with ``matrix`` or ``workspace``. 
+ *     Must not be ``NULL``.
+ * out_ld
+ *     The leading dimension of ``out``.
  */
 static inline void multiply_low_rank_dense(
-  const struct NodeOffDiagonal *restrict node,
-  const double *restrict matrix,
+  const struct NodeOffDiagonal *restrict const node,
+  const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
   const double beta2,
-  double *workspace,
-  double *out,
+  double *restrict const workspace,
+  double *restrict const out,
   const int out_ld
 ) {
   const double alpha = 1.0, beta1 = 0.0;
@@ -88,38 +100,51 @@ static inline void multiply_low_rank_dense(
 /**
  * Multiplies the transpose of a low-rank matrix and a dense matrix.
  *
- * Given an off-diagonal node (which represents a low-rank matrix) and a 
+ * Given an off-diagonal leaf node (which represents a low-rank matrix) and a 
  * dense matrix, transposes the low-rank matrix and computes the product of 
  * the two as a dense matrix.
  *
- * :param node: A pointer to the off-diagonal node to multiply. It must not be
+ * Parameters
+ * ----------
+ * node
+ *     Pointer to the off-diagonal node to multiply transposed. Must not be 
+ *     ``NULL``. Must point to a valid node with data allocated and set.
+ * matrix
+ *     Pointer representing an array containing the dense matrix to be 
+ *     multiplied. Must not be ``NULL``. Must not overlap with ``workspace``
+ *     or ``out``.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * beta2
+ *     The value of ``beta`` to use for the final ``dgesdd``. Determines 
+ *     whether results overwrite ``out`` or are added.
+ * workspace
+ *     Pointer representing a workspace array available for storing 
+ *     intermediate results. Must be of size at least ``node->s`` x 
+ *     ``matrix_n``. Must not overlap with ``matrix`` or ``out``. Must not be
+ *     ``NULL``.
+ * out
+ *     Pointer representing an array to which to store the result. Must be of
+ *     size at least ``m`` x ``matrix_n`` matrix, where ``m`` is the number of 
+ *     rows of ``node``. Must not overlap with ``matrix`` or ``workspace``. 
+ *     Must not be ``NULL``.
+ * out_ld
+ *     The leading dimension of ``out``.
+ * node
+ *     Pointer to the off-diagonal node to multiply. It must not be
  *              ``NULL`` and must point to a valid node with correctly 
  *              allocated and set values, anything else is undefined.
- * :param matrix: A pointer to an array containing the dense matrix to be used
- *                for the multiplication. Must not be ``NULL``. Must not 
- *                overlap with any other pointers.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param beta2: The value of ``beta`` to use for the final ``dgesdd``. 
- *               Determines whether results overwrite ``out`` or are added.
- * :param workspace: A pointer to a workspace array to be used. Must be large
- *                   enough to accomodate a ``s`` x ``matrix_n`` matrix where
- *                   ``s`` is the number of stored singular values on 
- *                   ``node``. Must not overlap with any other pointers.
- * :param out: A pointer to an array to which to store the result. Must be 
- *             large enough to accomodate a ``m`` x ``matrix_n`` matrix, where
- *             ``m`` is the number of rows of ``node``. Must not overlap with
- *             any other pointers.
- * :param out_ld: The leading dimension of ``out``.
  */
 static inline void multiply_low_rank_transpose_dense(
-  const struct NodeOffDiagonal *restrict node,
-  const double *restrict matrix,
+  const struct NodeOffDiagonal *restrict const node,
+  const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
   const double beta2,
-  double *workspace,
-  double *out,
+  double *restrict const workspace,
+  double *restrict const out,
   const int out_ld
 ) {
   const double alpha = 1.0, beta1 = 0.0;
@@ -134,216 +159,236 @@ static inline void multiply_low_rank_transpose_dense(
 /**
  * Multiplies two off-diagonal blocks with a dense matrix.
  *
- * Computes the matrix-matrix multiplication of the two off-diagonal blocks 
- * of a tree HODLR matrix internal node with a dense matrix, and adds the 
- * results to the ``out`` matrix.
+ * Computes the matrix-matrix multiplication of the two off-diagonal leaf
+ * children of an internal node with a dense matrix, and adds the results to 
+ * the ``out`` matrix.
  *
- * :param parent: Pointer to an internal node holding the off-diagonal nodes
- *                to multiply.
- * :param matrix: Pointer to an array holding the matrix being multiplied.
- *                This should be a pointer to the start of the array, and the
- *                ``offset_ptr`` parameter should be used for aligning the 
- *                matrix and the HODLR blocks. Must be in column-major order.
- *                Must not overlap with any of the other pointers - doing so
- *                is an undefined behaviour.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of
- *                   rows of the full array. Must be greater or equal to the
- *                   number of rows of the full HODLR matrix.
- * :param out: Pointer to an array to which the results are to be saved. This
- *             should be a pointer to the start of the array, and the 
- *             ``offset_ptr`` parameter should be used for aligning it with 
- *             the HODLR blocks.
- *             This array *must* be populated since the results are added to 
- *             it. The values not being set is an undefined behaviour.
- *             Must not overlap with any of the other pointers - doing so is 
- *             an undefined behaviour.
- * :param out_ld: Leading dimension of ``out``, i.e. the number of rows of the
- *                full array. Must be greater than or equal to the number of
- *                rows of the full HODLR matrix.
- * :param workspace: Pointer to an array that can be used as a workspace. 
- *                   Must be of at least size S x N where S is the number of 
- *                   retained singular values (the greater number between the
- *                   two off-diagonal nodes on ``parent``) and N is 
- *                   ``matrix_n``.
- *                   Must not overlap with any of the other arrays - doing 
- *                   so is an undefined behaviour.
- * :param offset: The current offset into ``matrix`` and ``out`` arrays.
+ * Parameters
+ * ----------
+ * parent
+ *     Pointer to the internal node whose off-diagonal children to multiply.
+ * matrix
+ *     Pointer representing an array holding the portion of the matrix to be
+ *     multiplied. A ``parent->m`` x ``matrix_n`` block of rows, starting with 
+ *     ``matrix[0]`` will be multiplied by ``parent``. Must not be ``NULL``.
+ *     Must not overlap with ``out`` or ``workspace``.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * out
+ *     Pointer representing an array to which the results are to be saved. A
+ *     ``parent->m`` x ``matrix_n`` block of columns, starting with 
+ *     ``out[0]``, will be added to ``out``
+ *     This array *must* be populated - the values not being set is an 
+ *     undefined behaviour. Similarly, it must not be ``NULL`` and must not
+ *     overlap with ``matrix`` or ``workspace``.
+ * out_ld
+ *     Leading dimension of ``out``.
+ * workspace
+ *     Pointer representing an array that can be used as a workspace. Must be 
+ *     of size at least S x ``matrix_n`` where S the greater rank between the
+ *     two off-diagonal children of ``parent. Must not be ``NULL`` and must 
+ *     not overlap with ``matrix`` or ``out``.
  *
- * :return: The new offset.
+ * Returns
+ * -------
+ * int
+ *     The offset increment, i.e. the size of the block written by this 
+ *     function - the next call of this function should pass in 
+ *     ``matrix + returned_val``.
  */
 static inline int multiply_off_diagonal_dense(
-  const struct HODLRInternalNode *restrict parent,
-  const double *restrict matrix,
+  const struct HODLRInternalNode *restrict const parent,
+  const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
-  double *restrict out,
+  double *restrict const out,
   const int out_ld,
-  double *restrict workspace,
-  const int offset
+  double *restrict const workspace
 ) {
   const double one = 1.0;
-  const int offset2 = offset + parent->children[1].leaf->data.off_diagonal.m;
+  const int m = parent->children[1].leaf->data.off_diagonal.m;
 
   multiply_low_rank_dense(
-    &parent->children[1].leaf->data.off_diagonal, matrix + offset2, matrix_n,
-    matrix_ld, one, workspace, out + offset, out_ld
+    &parent->children[1].leaf->data.off_diagonal, matrix + m, matrix_n,
+    matrix_ld, one, workspace, out, out_ld
   );
 
   multiply_low_rank_dense(
-    &parent->children[2].leaf->data.off_diagonal, matrix + offset, matrix_n,
-    matrix_ld, one, workspace, out + offset2, out_ld
+    &parent->children[2].leaf->data.off_diagonal, matrix, matrix_n,
+    matrix_ld, one, workspace, out + m, out_ld
   );
 
-  return offset2 + parent->children[1].leaf->data.off_diagonal.n;
+  return parent->m;
 }
 
 
 /**
  * Multiplies the transpose of two off-diagonal blocks with a dense matrix.
  *
- * Computes the matrix-matrix multiplication of the transpose of two 
- * off-diagonal blocks of a tree HODLR matrix internal node with a dense 
- * matrix, and adds the results to the ``out`` matrix.
+ * Computes the matrix-matrix multiplication of the transpose of an internal
+ * node (and its two off-diagonal children) with a dense matrix, and adds the 
+ * results to the ``out`` matrix.
  *
- * The two off-diagonal blocks are fully transposed - the two low-rank 
- * matrices are switched and each is transposed. (Of course, this is not 
- * performed separately but at the same time as the multiplication.)
+ * Parameters
+ * ----------
+ * parent
+ *     Pointer to the internal node whose off-diagonal children to multiply
+ *     transposed.
+ * matrix
+ *     Pointer representing an array holding the portion of the matrix to be
+ *     multiplied. A ``parent->m`` x ``matrix_n`` block of rows, starting with 
+ *     ``matrix[0]`` will be multiplied by ``parent``. Must not be ``NULL``.
+ *     Must not overlap with ``out`` or ``workspace``.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * out
+ *     Pointer representing an array to which the results are to be saved. A
+ *     ``parent->m`` x ``matrix_n`` block of columns, starting with 
+ *     ``out[0]``, will be added to ``out``
+ *     This array *must* be populated - the values not being set is an 
+ *     undefined behaviour. Similarly, it must not be ``NULL`` and must not
+ *     overlap with ``matrix`` or ``workspace``.
+ * out_ld
+ *     Leading dimension of ``out``.
+ * workspace
+ *     Pointer representing an array that can be used as a workspace. Must be 
+ *     of size at least S x ``matrix_n`` where S the greater rank between the
+ *     two off-diagonal children of ``parent. Must not be ``NULL`` and must 
+ *     not overlap with ``matrix`` or ``out``.
  *
- * :param parent: Pointer to an internal node holding the off-diagonal nodes
- *                to multiply.
- * :param matrix: Pointer to an array holding the matrix being multiplied.
- *                This should be a pointer to the start of the array, and the
- *                ``offset_ptr`` parameter should be used for aligning the 
- *                matrix and the HODLR blocks. Must be in column-major order.
- *                Must not overlap with any of the other pointers - doing so
- *                is an undefined behaviour.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of
- *                   rows of the full array. Must be greater or equal to the
- *                   number of rows of the full HODLR matrix.
- * :param out: Pointer to an array to which the results are to be saved. This
- *             should be a pointer to the start of the array, and the 
- *             ``offset_ptr`` parameter should be used for aligning it with 
- *             the HODLR blocks.
- *             This array *must* be populated since the results are added to 
- *             it. The values not being set is an undefined behaviour.
- *             Must not overlap with any of the other pointers - doing so is 
- *             an undefined behaviour.
- * :param out_ld: Leading dimension of ``out``, i.e. the number of rows of the
- *                full array. Must be greater than or equal to the number of
- *                rows of the full HODLR matrix.
- * :param workspace: Pointer to an array that can be used as a workspace. 
- *                   Must be of at least size S x N where S is the number of 
- *                   retained singular values (the greater number between the
- *                   two off-diagonal nodes on ``parent``) and N is 
- *                   ``matrix_n``.
- *                   Must not overlap with any of the other arrays - doing 
- *                   so is an undefined behaviour.
- * :param offset: The current offset into ``matrix`` and ``out`` arrays.
- *
- * :return: The new offset.
+ * Returns
+ * -------
+ * int
+ *     The offset increment, i.e. the size of the block written by this 
+ *     function - the next call of this function should pass in 
+ *     ``matrix + returned_val``.
  */
 static inline int multiply_off_diagonal_transpose_dense(
-  const struct HODLRInternalNode *restrict parent,
-  const double *restrict matrix,
+  const struct HODLRInternalNode *restrict const parent,
+  const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
-  double *restrict out,
+  double *restrict const out,
   const int out_ld,
-  double *restrict workspace,
-  int offset
+  double *restrict const workspace
 ) {
   const double one = 1.0;
   
-  const int offset2 = offset + parent->children[1].leaf->data.off_diagonal.m;
+  const int m = parent->children[1].leaf->data.off_diagonal.m;
 
   multiply_low_rank_transpose_dense(
-    &parent->children[2].leaf->data.off_diagonal, matrix + offset2, matrix_n,
-    matrix_ld, one, workspace, out + offset, out_ld
+    &parent->children[2].leaf->data.off_diagonal, matrix + m, matrix_n,
+    matrix_ld, one, workspace, out, out_ld
   );
 
   multiply_low_rank_transpose_dense(
-    &parent->children[1].leaf->data.off_diagonal, matrix + offset, matrix_n,
-    matrix_ld, one, workspace, out + offset2, out_ld
+    &parent->children[1].leaf->data.off_diagonal, matrix, matrix_n,
+    matrix_ld, one, workspace, out + m, out_ld
   );
 
-  return offset2 + parent->children[1].leaf->data.off_diagonal.n;
+  return parent->m;
 }
 
 
 /**
- * Multiplies a tree HODLR matrix by a dense matrix as a dense matrix.
+ * Performs a matrix-matrix multiplication of a HODLR and a dense matrix, 
+ * returning a dense matrix.
  *
- * Given a HODLR tree and a dense matrix array, computes the matrix-matrix 
- * multiplication and returns the result as a dense matrix.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR tree to multiply. This must be a fully constructed 
+ *     HODLR tree, filled with data. If ``NULL``, the function will 
+ *     immediately abort.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to be 
+ *     multiplied. Must be of size ``matrix_ld`` x ``matrix_n`` of which a M x
+ *     ``matrix_n`` submatrix will be used for the multiplication (where M is 
+ *     the number of rows of ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``.
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will be 
+ *     stored in column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with values (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
+ *     allocated with size ``out_ld`` x ``matrix_n``.
+ * ierr
+ *     Pointer to an integer hodling the :c:member:`ErrorCode.SUCCESS` value. 
+ *     Used to signal the success or failure of this function. An error status 
+ *     code from :c:enum:`ErrorCode` is written into the pointer 
+ *     **if an error occurs**. Must not be ``NULL`` - doing so is undefined.
  *
- * :param hodlr: Pointer to the HODLR tree to multiply. This must be a 
- *               fully constructed HODLR tree, including all the data being 
- *               filled in. If the data has not been assigned (e.g. by using
- *               :c:func:`dense_to_tree_hodlr`), it will lead to undefined
- *               behaviour.
- *               If ``NULL``, the function will immediately abort.
- * :param matrix: Pointer to an array storing the dense matrix to use for the
- *                multiplication. Must be of size ``matrix_ld`` x ``matrix_n``
- *                of which M x ``matrix_n`` submatrix will be used for the 
- *                multiplication (where M is the number of rows of ``hodlr``).
- *                Must be stored in column-major order.
- *                Must not overlap with ``out`` and must be occupied with 
- *                values - either will lead to undefined behaviour.
- *                If ``NULL``, the function will immediately abort.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of 
- *                   rows of the full array. Must be greater than or equal to 
- *                   the number of rows of ``hodlr``.
- * :param out: Pointer to an array to be used for storing the results of the
- *             multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will
- *             be stored in column-major order.
- *             Must not overlap with ``vector``, otherwise undefined behaviour
- *             will ensue, but may be both filled with value (which will be
- *             overwritten) or empty (i.e. just allocated).
- *             If ``NULL``, a new array is allocated.
- * :param out_ld: The leading dimension of ``out``, i.e. the number of rows of
- *                the full array. Must be greater than or equal to the number
- *                of rows of ``hodlr``, even if ``out == NULL``, in which case
- *                ``out`` will be allocated with size ``out_ld`` x 
- *                ``matrix_n``.
- * :return: The ``out`` array with the results of the matrix-matrix
- *          multiplication stored inside.
+ * Returns
+ * -------
+ * double*
+ *     The ``out`` array with the results of the matrix-matrix multiplication 
+ *     stored inside.
+ *
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``hodlr`` or ``matrix`` is ``NULL`` or if ``matrix`` and ``out`` 
+ *     point to the same memory location.
+ * ALLOCATION_FAILURE
+ *     If ``out == NULL`` and its allocation fails.
  */
-double * multiply_hodlr_dense(const struct TreeHODLR *hodlr,
-                              const double *restrict matrix,
-                              const int matrix_n,
-                              const int matrix_ld,
-                              double *restrict out,
-                              const int out_ld) {
-  if (hodlr == NULL || matrix == NULL) {
+double * multiply_hodlr_dense(
+  const struct TreeHODLR *restrict const hodlr,
+  const double *restrict const matrix,
+  const int matrix_n,
+  const int matrix_ld,
+  double *restrict out,
+  const int out_ld,
+  int *restrict const ierr
+) {
+  if (hodlr == NULL || matrix == NULL || matrix == out) {
+    *ierr = INPUT_ERROR;
     return NULL;
   }
   if (out == NULL) {
     out = malloc(out_ld * matrix_n * sizeof(double));
     if (out == NULL) {
+      *ierr = ALLOCATION_FAILURE;
       return NULL;
     }
   }
-
-  int offset = 0, idx=0, m = 0;
-  long n_parent_nodes = hodlr->len_work_queue;
-  const double alpha = 1.0, beta = 0.0;
+  *ierr = SUCCESS;
 
   int workspace_size = compute_multiply_hodlr_dense_workspace(hodlr, matrix_n);
   double *workspace = malloc(workspace_size * sizeof(double));
 
+  long n_parent_nodes = hodlr->len_work_queue;
   struct HODLRInternalNode **queue = hodlr->work_queue;
-  
-  for (int i = 0; i < n_parent_nodes; i++) {
-    queue[i] = hodlr->innermost_leaves[2 * i]->parent;
+
+  int offset = 0;
+  const double alpha = 1.0, beta = 0.0;
+
+  for (int parent = 0; parent < n_parent_nodes; parent++) {
+    queue[parent] = hodlr->innermost_leaves[2 * parent]->parent;
 
     for (int j = 0; j < 2; j++) {
-      idx = 2 * i + j;
-      m = hodlr->innermost_leaves[idx]->data.diagonal.m;
+      const int m = hodlr->innermost_leaves[2 * parent + j]->data.diagonal.m;
       dgemm_("N", "N", &m, &matrix_n, &m, &alpha, 
-             hodlr->innermost_leaves[idx]->data.diagonal.data, 
+             hodlr->innermost_leaves[2 * parent + j]->data.diagonal.data, 
              &m, matrix + offset, &matrix_ld,
              &beta, out + offset, &out_ld);
       
@@ -355,23 +400,20 @@ double * multiply_hodlr_dense(const struct TreeHODLR *hodlr,
     n_parent_nodes /= 2;
     offset = 0;
 
-    for (int j = 0; j < n_parent_nodes; j++) {
-      idx = 2 * j;
-      for (int k = 0; k < 2; k++) {
-        offset = multiply_off_diagonal_dense(
-          queue[idx], matrix, matrix_n, matrix_ld, 
-          out, out_ld, workspace, offset
+    for (int parent = 0; parent < n_parent_nodes; parent++) {
+      for (int leaf = 0; leaf < 2; leaf++) {
+        offset += multiply_off_diagonal_dense(
+          queue[2 * parent + leaf], matrix + offset, matrix_n, matrix_ld, 
+          out + offset, out_ld, workspace
         );
-
-        idx += 1;
       }
 
-      queue[j] = queue[2 * j + 1]->parent;
+      queue[parent] = queue[2 * parent + 1]->parent;
     }
   }
 
   multiply_off_diagonal_dense(
-    hodlr->root, matrix, matrix_n, matrix_ld, out, out_ld, workspace, 0
+    hodlr->root, matrix, matrix_n, matrix_ld, out, out_ld, workspace
   );
 
   free(workspace);
@@ -387,34 +429,52 @@ double * multiply_hodlr_dense(const struct TreeHODLR *hodlr,
  * Given an internal node and its height, and a dense matrix, computes their
  * product as a dense matrix.
  *
- * :param internal: A pointer to the internal node representing a HODLR matrix
- *                  to multiply. Must not be NULL and must be correctly 
- *                  allocated and fully constructed - anything else is 
- *                  undefined.
- * :param height: The height of the HODLR matrix represented by ``internal``.
- *                This must correspond with the number of internal nodes 
- *                starting from ``internal`` (including) all the way to the 
- *                bottom of the tree.
- * :param matrix: A pointer to access an array containing the matrix to 
- *                multiply. Must not be ``NULL`` and must be large enough to 
- *                store the ``matrix_ld`` x ``matrix_n`` matrix.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param queue: A pointer to access an array of pointers to internal nodes.
- *               This is a workspace array used to loop over the tree. Must 
- *               not be ``NULL``.
- * :param workspace: A pointer to access an array containing enough space 
- *                   to store an ``s`` x ``matrix_n`` matrix, where ``s`` is 
- *                   the largest number of singular values kept on any leaf 
- *                   node of the ``internal`` tree. Must not be ``NULL``.
- * :param workspace2: A pointer to access an array containing enough space to
- *                    store an ``m`` x ``matrix_n`` matrix, where ``m`` is the
- *                    number of rows of the largest block of the ``internal``
- *                    tree. Must not be ``NULL``.
- * :param out: A pointer to access an array to be used to save the results.
- *             Must be large enough to store a ``out_ld`` x ``matrix_n`` 
- *             matrix. Must not be ``NULL``.
- * :param out_ld: The leading dimension of ``out``.
+ * Parameters
+ * ----------
+ * internal
+ *     Pointer to the internal node representing a HODLR matrix to multiply. 
+ *     Must not be ``NULL`` and must be fully constructed - anything else will
+ *     result in undefined behaviour.
+ * height
+ *     The height of the HODLR matrix represented by ``internal``. This must 
+ *     correspond with the number of internal nodes starting from ``internal`` 
+ *     (including) all the way to the bottom of the tree.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to be 
+ *     multiplied. Must be of size ``matrix_ld`` x ``matrix_n`` of which a M x
+ *     ``matrix_n`` submatrix will be used for the multiplication (where M is 
+ *     the number of rows of ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``.
+ * queue
+ *     Pointer representing an array of pointers to internal nodes. This is a 
+ *     workspace array used to loop over the tree. Must be of length at least
+ *     :math:`2^{height-1}`. Must not be ``NULL``.
+ * workspace
+ *     Pointer representing an array to be used as a workspace matrix. Must be 
+ *     of size at least ``s`` x ``matrix_n`` matrix, where ``s`` is the 
+ *     largest rank of any off-diagonal leaf node on the ``internal`` tree. 
+ *     Must not be ``NULL``.
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will be 
+ *     stored in column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with value (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
+ *     allocated with size ``out_ld`` x ``matrix_n``.
  */
 void multiply_internal_node_dense(
   const struct HODLRInternalNode *restrict const internal,
@@ -422,17 +482,13 @@ void multiply_internal_node_dense(
   const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
-  const struct HODLRInternalNode **restrict queue,
+  const struct HODLRInternalNode **queue,
   double *restrict workspace,
   double *restrict out,
   const int out_ld
 ) {
-  int len_queue = 1, q_next_node_density = (int)pow(2, height-1);
-  int q_current_node_density = q_next_node_density;
-  int idx = 0, offset = 0;
   const double alpha = 1.0, beta = 0.0;
-
-  int m = internal->children[1].leaf->data.off_diagonal.m;
+  const int m = internal->children[1].leaf->data.off_diagonal.m;
 
   multiply_low_rank_dense(&internal->children[1].leaf->data.off_diagonal,
                           matrix + m, matrix_n, matrix_ld, beta,
@@ -442,6 +498,10 @@ void multiply_internal_node_dense(
                           matrix, matrix_n, matrix_ld, beta,
                           workspace, out + m, out_ld);
 
+  int idx = 0, offset = 0;
+  int len_queue = 1, q_next_node_density = (int)pow(2, height-1);
+  int q_current_node_density = q_next_node_density;
+
   queue[0] = internal;
   for (int _ = 1; _ < height; _++) {
     q_next_node_density /= 2;
@@ -450,9 +510,10 @@ void multiply_internal_node_dense(
     for (int parent = 0; parent < len_queue; parent++) {
       idx = parent * q_current_node_density;
       for (int child = 0; child < 4; child += 3) {
-        offset = multiply_off_diagonal_dense(
-          queue[idx]->children[child].internal, matrix, matrix_n, matrix_ld, 
-          out, out_ld, workspace, offset
+        offset += multiply_off_diagonal_dense(
+          queue[idx]->children[child].internal, 
+          matrix + offset, matrix_n, matrix_ld, 
+          out + offset, out_ld, workspace
         );
       }
 
@@ -467,7 +528,7 @@ void multiply_internal_node_dense(
   offset = 0;
   for (int node = 0; node < len_queue; node++) {
     for (int child = 0; child < 4; child+=3) {
-      m = queue[node]->children[child].leaf->data.diagonal.m;
+      const int m = queue[node]->children[child].leaf->data.diagonal.m;
       dgemm_("N", "N", &m, &matrix_n, &m, &alpha, 
               queue[node]->children[child].leaf->data.diagonal.data, 
               &m, matrix + offset, &matrix_ld,
@@ -479,70 +540,90 @@ void multiply_internal_node_dense(
 
 
 /**
- * Multiplies the transpose of a tree HODLR matrix by a dense matrix as a 
- * dense matrix.
+ * Performs a matrix-matrix multiplication of the transpose of a HODLR and a 
+ * dense matrix, returning a dense matrix.
  *
- * Given a HODLR tree and a dense matrix array, transposes the HODLR tree,
- * computes the matrix-matrix multiplication and returns the result as a 
- * dense matrix.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR tree to multiply transposed. This must be a fully 
+ *     constructed HODLR tree, filled with data. If ``NULL``, the function 
+ *     will immediately abort.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to be 
+ *     multiplied. Must be of size ``matrix_ld`` x ``matrix_n`` of which a M x
+ *     ``matrix_n`` submatrix will be used for the multiplication (where M is 
+ *     the number of rows of ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``.
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will be 
+ *     stored in column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with value (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
+ *     allocated with size ``out_ld`` x ``matrix_n``.
+ * ierr
+ *     Pointer to an integer hodling the :c:member:`ErrorCode.SUCCESS` value. 
+ *     Used to signal the success or failure of this function. An error status 
+ *     code from :c:enum:`ErrorCode` is written into the pointer 
+ *     **if an error occurs**. Must not be ``NULL`` - doing so is undefined.
  *
- * :param hodlr: Pointer to the HODLR tree to multiply. This must be a 
- *               fully constructed HODLR tree, including all the data being 
- *               filled in. If the data has not been assigned (e.g. by using
- *               :c:func:`dense_to_tree_hodlr`), it will lead to undefined
- *               behaviour.
- *               If ``NULL``, the function will immediately abort.
- * :param matrix: Pointer to an array storing the dense matrix to use for the
- *                multiplication. Must be of size ``matrix_ld`` x ``matrix_n``
- *                of which M x ``matrix_n`` submatrix will be used for the 
- *                multiplication (where M is the number of rows of ``hodlr``).
- *                Must be stored in column-major order.
- *                Must not overlap with ``out`` and must be occupied with 
- *                values - either will lead to undefined behaviour.
- *                If ``NULL``, the function will immediately abort.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of 
- *                   rows of the full array. Must be greater than or equal to 
- *                   the number of rows of ``hodlr``.
- * :param out: Pointer to an array to be used for storing the results of the
- *             multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will
- *             be stored in column-major order.
- *             Must not overlap with ``vector``, otherwise undefined behaviour
- *             will ensue, but may be both filled with value (which will be
- *             overwritten) or empty (i.e. just allocated).
- *             If ``NULL``, a new array is allocated.
- * :param out_ld: The leading dimension of ``out``, i.e. the number of rows of
- *                the full array. Must be greater than or equal to the number
- *                of rows of ``hodlr``, even if ``out == NULL``, in which case
- *                ``out`` will be allocated with size ``out_ld`` x 
- *                ``matrix_n``.
- * :return: The ``out`` array with the results of the matrix-matrix
- *          multiplication stored inside.
+ * Returns
+ * -------
+ * double*
+ *     The ``out`` array with the results of the matrix-matrix multiplication 
+ *     stored inside.
+ *
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``hodlr`` or ``matrix`` is ``NULL`` or if ``matrix`` and ``out`` 
+ *     point to the same memory location.
+ * ALLOCATION_FAILURE
+ *     If ``out == NULL`` and its allocation fails.
  */
-double * multiply_hodlr_transpose_dense(const struct TreeHODLR *hodlr,
-                                        const double *restrict matrix,
-                                        const int matrix_n,
-                                        const int matrix_ld,
-                                        double *restrict out,
-                                        const int out_ld) {
-  if (hodlr == NULL || matrix == NULL) {
+double * multiply_hodlr_transpose_dense(
+  const struct TreeHODLR *restrict const hodlr,
+  const double *restrict const matrix,
+  const int matrix_n,
+  const int matrix_ld,
+  double *restrict out,
+  const int out_ld,
+  int *restrict const ierr
+) {
+  if (hodlr == NULL || matrix == NULL || matrix == out) {
+    *ierr = INPUT_ERROR;
     return NULL;
   }
   if (out == NULL) {
     out = malloc(out_ld * matrix_n * sizeof(double));
     if (out == NULL) {
+      *ierr = ALLOCATION_FAILURE;
       return NULL;
     }
   }
+  *ierr = SUCCESS;
 
   int workspace_size = compute_multiply_hodlr_dense_workspace(hodlr, matrix_n);
   double *workspace = malloc(workspace_size * sizeof(double));
 
-  struct HODLRInternalNode **queue = hodlr->work_queue;
-
   multiply_internal_node_transpose_dense(
-    hodlr->root, hodlr->height, matrix, matrix_n, matrix_ld, queue, workspace, 
-    out, out_ld
+    hodlr->root, hodlr->height, matrix, matrix_n, matrix_ld, 
+    hodlr->work_queue, workspace, out, out_ld
   );
 
   return out;
@@ -550,54 +631,72 @@ double * multiply_hodlr_transpose_dense(const struct TreeHODLR *hodlr,
 
 
 /**
- * Multiplies the transpose of a HODLR matrix represented by an internal 
- * node and a dense matrix.
+ * Multiplies the transpose of a HODLR matrix represented by an internal node 
+ * and a dense matrix.
  *
- * Given an internal node and its height, and a dense matrix, transposes the
- * internal node and computes their product as a dense matrix.
+ * Given an internal node and its height, and a dense matrix, computes their
+ * product as a dense matrix.
  *
- * :param internal: A pointer to the internal node representing a HODLR matrix
- *                  to multiply. Must not be NULL and must be correctly 
- *                  allocated and fully constructed - anything else is 
- *                  undefined.
- * :param height: The height of the HODLR matrix represented by ``internal``.
- *                This must correspond with the number of internal nodes 
- *                starting from ``internal`` (including) all the way to the 
- *                bottom of the tree.
- * :param matrix: A pointer to access an array containing the matrix to 
- *                multiply. Must not be ``NULL`` and must be large enough to 
- *                store the ``matrix_ld`` x ``matrix_n`` matrix.
- * :param matrix_n: The number of columns of ``matrix``.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param queue: A pointer to access an array of pointers to internal nodes.
- *               This is a workspace array used to loop over the tree. Must 
- *               not be ``NULL``.
- * :param workspace: A pointer to access an array containing enough space 
- *                   to store an ``s`` x ``matrix_n`` matrix, where ``s`` is 
- *                   the largest number of singular values kept on any leaf 
- *                   node of the ``internal`` tree. Must not be ``NULL``.
- * :param out: A pointer to access an array to be used to save the results.
- *             Must be large enough to store a ``out_ld`` x ``matrix_n`` 
- *             matrix. Must not be ``NULL``.
- * :param out_ld: The leading dimension of ``out``.
+ * Parameters
+ * ----------
+ * internal
+ *     Pointer to the internal node representing a HODLR matrix to multiply
+ *     transposed. Must not be ``NULL`` and must be fully constructed - 
+ *     anything else will result in undefined behaviour.
+ * height
+ *     The height of the HODLR matrix represented by ``internal``. This must 
+ *     correspond with the number of internal nodes starting from ``internal`` 
+ *     (including) all the way to the bottom of the tree.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to be 
+ *     multiplied. Must be of size ``matrix_ld`` x ``matrix_n`` of which a M x
+ *     ``matrix_n`` submatrix will be used for the multiplication (where M is 
+ *     the number of rows of ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_n
+ *     The number of columns of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``.
+ * queue
+ *     Pointer representing an array of pointers to internal nodes. This is a 
+ *     workspace array used to loop over the tree. Must be of length at least
+ *     :math:`2^{height-1}`. Must not be ``NULL``.
+ * workspace
+ *     Pointer representing an array to be used as a workspace matrix. Must be 
+ *     of size at least ``s`` x ``matrix_n`` matrix, where ``s`` is the 
+ *     largest rank of any off-diagonal leaf node on the ``internal`` tree. 
+ *     Must not be ``NULL``.
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will be 
+ *     stored in column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with value (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to the number of rows of 
+ *     ``hodlr``, even if ``out == NULL``, in which case ``out`` will be 
+ *     allocated with size ``out_ld`` x ``matrix_n``.
  */
 void multiply_internal_node_transpose_dense(
-  const struct HODLRInternalNode *restrict internal,
+  const struct HODLRInternalNode *restrict const internal,
   const int height,
-  const double *restrict matrix,
+  const double *restrict const matrix,
   const int matrix_n,
   const int matrix_ld,
-  const struct HODLRInternalNode **restrict queue,
-  double *restrict workspace,
-  double *restrict out,
+  const struct HODLRInternalNode **queue,
+  double *restrict const workspace,
+  double *restrict const out,
   const int out_ld
 ) {
-  int len_queue = 1, q_next_node_density = (int)pow(2, height-1);
-  int q_current_node_density = q_next_node_density;
-  int idx = 0, offset = 0;
   const double alpha = 1.0, beta = 0.0;
-
-  int m = internal->children[1].leaf->data.off_diagonal.m;
+  const int m = internal->children[1].leaf->data.off_diagonal.m;
 
   multiply_low_rank_transpose_dense(
     &internal->children[2].leaf->data.off_diagonal, matrix + m, matrix_n, 
@@ -609,6 +708,10 @@ void multiply_internal_node_transpose_dense(
     matrix_ld, beta, workspace, out + m, out_ld
   );
 
+  int len_queue = 1, q_next_node_density = (int)pow(2, height-1);
+  int q_current_node_density = q_next_node_density;
+  int idx = 0, offset = 0;
+
   queue[0] = internal;
   for (int _ = 1; _ < height; _++) {
     q_next_node_density /= 2;
@@ -617,9 +720,9 @@ void multiply_internal_node_transpose_dense(
     for (int parent = 0; parent < len_queue; parent++) {
       idx = parent * q_current_node_density;
       for (int child = 0; child < 4; child += 3) {
-        offset = multiply_off_diagonal_transpose_dense(
+        offset += multiply_off_diagonal_transpose_dense(
           queue[idx]->children[child].internal,
-          matrix, matrix_n, matrix_ld, out, out_ld, workspace, offset
+          matrix + offset, matrix_n, matrix_ld, out + offset, out_ld, workspace
         );
       }
 
@@ -634,7 +737,7 @@ void multiply_internal_node_transpose_dense(
   offset = 0;
   for (int node = 0; node < len_queue; node++) {
     for (int child = 0; child < 4; child+=3) {
-      m = queue[node]->children[child].leaf->data.diagonal.m;
+      const int m = queue[node]->children[child].leaf->data.diagonal.m;
       dgemm_("T", "N", &m, &matrix_n, &m, &alpha, 
               queue[node]->children[child].leaf->data.diagonal.data, 
               &m, matrix + offset, &matrix_ld,
@@ -651,25 +754,33 @@ void multiply_internal_node_transpose_dense(
  * Given a dense matrix and an off-diagonal node (which represents a low-rank 
  * matrix), computies the product of the two as a dense matrix.
  *
- * :param node: A pointer to the off-diagonal node to multiply. It must not be
- *              ``NULL`` and must point to a valid node with correctly 
- *              allocated and set values, anything else is undefined.
- * :param matrix: A pointer to an array containing the dense matrix to be used
- *                for the multiplication. Must not be ``NULL``. Must not 
- *                overlap with any other pointers.
- * :param matrix_m: The number of rows of ``matrix`` to multiply.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param beta2: The value of ``beta`` to use for the final ``dgesdd``. 
- *               Determines whether results overwrite ``out`` or are added.
- * :param workspace: A pointer to a workspace array to be used. Must be large
- *                   enough to accomodate a ``s`` x ``matrix_n`` matrix where
- *                   ``s`` is the number of stored singular values on 
- *                   ``node``. Must not overlap with any other pointers.
- * :param out: A pointer to an array to which to store the result. Must be 
- *             large enough to accomodate a ``m`` x ``matrix_n`` matrix, where
- *             ``m`` is the number of rows of ``node``. Must not overlap with
- *             any other pointers.
- * :param out_ld: The leading dimension of ``out``.
+ * Parameters
+ * ----------
+ * node
+ *     Pointer to the off-diagonal node to be multiplied. Must not be 
+ *     ``NULL``. Must point to a valid node with data allocated and set.
+ * matrix
+ *     Pointer representing an array containing the dense matrix to multiply.
+ *     Must not be ``NULL``. Must not overlap with ``workspace`` or ``out``.
+ * matrix_m
+ *     The number of rows of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * beta2
+ *     The value of ``beta`` to use for the final ``dgesdd``. Determines 
+ *     whether results overwrite ``out`` or are added.
+ * workspace
+ *     Pointer representing a workspace array available for storing 
+ *     intermediate results. Must be of size at least ``matrix_m`` x 
+ *     ``node->s``. Must not overlap with ``matrix`` or ``out``. Must not be
+ *     ``NULL``.
+ * out
+ *     Pointer representing an array to which to store the result. Must be of
+ *     size at least ``matrix_m`` x ``m`` matrix, where ``m`` is the number of 
+ *     rows of ``node``. Must not overlap with ``matrix`` or ``workspace``. 
+ *     Must not be ``NULL``.
+ * out_ld
+ *     The leading dimension of ``out``.
  */
 static inline void multiply_dense_low_rank(
   const struct NodeOffDiagonal *restrict const node,
@@ -693,43 +804,45 @@ static inline void multiply_dense_low_rank(
 /**
  * Multiplies a dense matrix with two off-diagonal blocks.
  *
- * Computes the matrix-matrix multiplication of a dense matrix with two 
- * off-diagonal blocks of a tree HODLR matrix internal node, and adds the 
- * results to the ``out`` matrix.
+ * Computes the matrix-matrix multiplication of a dense matrix with the two 
+ * off-diagonal leaf children of an internal node, and adds the results to 
+ * the ``out`` matrix.
  *
- * :param parent: Pointer to an internal node holding the off-diagonal nodes
- *                to multiply.
- * :param matrix: Pointer to an array holding the matrix being multiplied.
- *                This should be a pointer to the start of the array, and the
- *                ``offset_ptr`` parameter should be used for aligning the 
- *                matrix and the HODLR blocks. Must be in column-major order.
- *                Must not overlap with any of the other pointers - doing so
- *                is an undefined behaviour.
- * :param matrix_m: The number of rows of ``matrix`` to multiply.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of
- *                   rows of the full array. Must be greater or equal to the
- *                   number of rows of the full HODLR matrix.
- * :param out: Pointer to an array to which the results are to be saved. This
- *             should be a pointer to the start of the array, and the 
- *             ``offset_ptr`` parameter should be used for aligning it with 
- *             the HODLR blocks.
- *             This array *must* be populated since the results are added to 
- *             it. The values not being set is an undefined behaviour.
- *             Must not overlap with any of the other pointers - doing so is 
- *             an undefined behaviour.
- * :param out_ld: Leading dimension of ``out``, i.e. the number of rows of the
- *                full array. Must be greater than or equal to the number of
- *                rows of the full HODLR matrix.
- * :param workspace: Pointer to an array that can be used as a workspace. 
- *                   Must be of at least size S x N where S is the number of 
- *                   retained singular values (the greater number between the
- *                   two off-diagonal nodes on ``parent``) and N is 
- *                   ``matrix_n``.
- *                   Must not overlap with any of the other arrays - doing 
- *                   so is an undefined behaviour.
- * :param offset: The current offset into ``matrix`` and ``out`` arrays.
+ * Parameters
+ * ----------
+ * parent
+ *     Pointer to the internal node whose off-diagonal children are to be 
+ *     multiplied.
+ * matrix
+ *     Pointer representing an array holding the portion of the matrix to
+ *     multiply. A ``matrix_m`` x ``parent->m`` block of columns, starting 
+ *     with ``matrix[0]`` will be multiply ``parent``. Must not be ``NULL``.
+ *     Must not overlap with ``out`` or ``workspace``.
+ * matrix_m
+ *     The number of rows of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``.
+ * out
+ *     Pointer representing an array to which the results are to be saved. A
+ *     ``matrix_m`` x ``parent->m`` block of rows, starting with ``out[0]``, 
+ *     will be added to ``out``
+ *     This array *must* be populated - the values not being set is an 
+ *     undefined behaviour. Similarly, it must not be ``NULL`` and must not
+ *     overlap with ``matrix`` or ``workspace``.
+ * out_ld
+ *     Leading dimension of ``out``.
+ * workspace
+ *     Pointer representing an array that can be used as a workspace. Must be 
+ *     of size at least S x ``matrix_m`` where S the greater rank between the
+ *     two off-diagonal children of ``parent. Must not be ``NULL`` and must 
+ *     not overlap with ``matrix`` or ``out``.
  *
- * :return: The new offset.
+ * Returns
+ * -------
+ * int
+ *     The offset increment, i.e. the size of the block written by this 
+ *     function - the next call of this function should pass in 
+ *     ``matrix + returned_val * matrix_ld``.
  */
 static inline int multiply_dense_off_diagonal(
   const struct HODLRInternalNode *restrict parent,
@@ -738,125 +851,145 @@ static inline int multiply_dense_off_diagonal(
   const int matrix_ld,
   double *restrict out,
   const int out_ld,
-  double *restrict workspace,
-  const int offset
+  double *restrict workspace
 ) {
   const double one = 1.0;
-  const int offset2 = offset + parent->children[1].leaf->data.off_diagonal.m;
+  const int m = parent->children[1].leaf->data.off_diagonal.m;
 
   multiply_dense_low_rank(
-    &parent->children[1].leaf->data.off_diagonal, matrix + offset * matrix_ld, 
-    matrix_m, matrix_ld, one, workspace, out + offset2 * out_ld, out_ld
+    &parent->children[1].leaf->data.off_diagonal, matrix, 
+    matrix_m, matrix_ld, one, workspace, out + m * out_ld, out_ld
   );
 
   multiply_dense_low_rank(
-    &parent->children[2].leaf->data.off_diagonal, matrix + offset2 * matrix_ld, 
-    matrix_m, matrix_ld, one, workspace, out + offset * out_ld, out_ld
+    &parent->children[2].leaf->data.off_diagonal, matrix + m * matrix_ld, 
+    matrix_m, matrix_ld, one, workspace, out, out_ld
   );
 
-  return offset2 + parent->children[1].leaf->data.off_diagonal.n;
+  return parent->m;
 }
 
 
 /**
- * Multiplies a dense matrix by a tree HODLR matrix as a dense matrix.
+ * Performs a matrix-matrix multiplication of a HODLR and a dense matrix, 
+ * returning a dense matrix.
  *
- * Given a dense matrix and a HODLR tree, computes the matrix-matrix 
- * multiplication and returns the result as a dense matrix.
+ * Parameters
+ * ----------
+ * hodlr
+ *     Pointer to the HODLR tree to be multiplied. Must be a fully constructed 
+ *     HODLR tree, filled with data. If ``NULL``, the function will 
+ *     immediately abort.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to multiply.
+ *     Must be of size ``matrix_ld`` x M of which a ``matrix_m`` x M submatrix 
+ *     will be used for the multiplication (where M is the number of rows of 
+ *     ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_m
+ *     The number of rows of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to ``matrix_m``. 
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x M. Will be stored in 
+ *     column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with values (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to ``matrix_m``, even if 
+ *     ``out == NULL``, in which case ``out`` will be allocated with size 
+ *     ``out_ld`` x M.
+ * ierr
+ *     Pointer to an integer hodling the :c:member:`ErrorCode.SUCCESS` value. 
+ *     Used to signal the success or failure of this function. An error status 
+ *     code from :c:enum:`ErrorCode` is written into the pointer 
+ *     **if an error occurs**. Must not be ``NULL`` - doing so is undefined.
  *
- * :param hodlr: Pointer to the HODLR tree to multiply. This must be a 
- *               fully constructed HODLR tree, including all the data being 
- *               filled in. If the data has not been assigned (e.g. by using
- *               :c:func:`dense_to_tree_hodlr`), it will lead to undefined
- *               behaviour.
- *               If ``NULL``, the function will immediately abort.
- * :param matrix: Pointer to an array storing the dense matrix to use for the
- *                multiplication. Must be of size ``matrix_ld`` x ``matrix_n``
- *                of which M x ``matrix_n`` submatrix will be used for the 
- *                multiplication (where M is the number of rows of ``hodlr``).
- *                Must be stored in column-major order.
- *                Must not overlap with ``out`` and must be occupied with 
- *                values - either will lead to undefined behaviour.
- *                If ``NULL``, the function will immediately abort.
- * :param matrix_m: The number of rows of ``matrix`` to multiply.
- * :param matrix_ld: The leading dimension of ``matrix``, i.e. the number of 
- *                   rows of the full array. Must be greater than or equal to 
- *                   the number of rows of ``hodlr``.
- * :param out: Pointer to an array to be used for storing the results of the
- *             multiplication. Must be of size ``out_ld`` x ``matrix_n``. Will
- *             be stored in column-major order.
- *             Must not overlap with ``vector``, otherwise undefined behaviour
- *             will ensue, but may be both filled with value (which will be
- *             overwritten) or empty (i.e. just allocated).
- *             If ``NULL``, a new array is allocated.
- * :param out_ld: The leading dimension of ``out``, i.e. the number of rows of
- *                the full array. Must be greater than or equal to the number
- *                of rows of ``hodlr``, even if ``out == NULL``, in which case
- *                ``out`` will be allocated with size ``out_ld`` x 
- *                ``matrix_n``.
- * :return: The ``out`` array with the results of the matrix-matrix
- *          multiplication stored inside.
+ * Returns
+ * -------
+ * double*
+ *     The ``out`` array with the results of the matrix-matrix multiplication 
+ *     stored inside.
+ *
+ * Errors
+ * ------
+ * INPUT_ERROR
+ *     If ``hodlr`` or ``matrix`` is ``NULL`` or if ``matrix`` and ``out`` 
+ *     point to the same memory location.
+ * ALLOCATION_FAILURE
+ *     If ``out == NULL`` and its allocation fails.
  */
-double * multiply_dense_hodlr(const struct TreeHODLR *hodlr,
-                              const double *restrict matrix,
-                              const int matrix_m,
-                              const int matrix_ld,
-                              double *restrict out,
-                              const int out_ld) {
-  if (hodlr == NULL || matrix == NULL) {
+double * multiply_dense_hodlr(
+  const struct TreeHODLR *restrict const hodlr,
+  const double *restrict const matrix,
+  const int matrix_m,
+  const int matrix_ld,
+  double *restrict out,
+  const int out_ld,
+  int *restrict const ierr
+) {
+  if (hodlr == NULL || matrix == NULL || matrix == out) {
+    *ierr = INPUT_ERROR;
     return NULL;
   }
   if (out == NULL) {
     out = malloc(out_ld * hodlr->root->m * sizeof(double));
     if (out == NULL) {
+      *ierr = ALLOCATION_FAILURE;
       return NULL;
     }
   }
-
-  int offset = 0, idx=0, m = 0;
-  long n_parent_nodes = hodlr->len_work_queue;
-  const double alpha = 1.0, beta = 0.0;
+  *ierr = SUCCESS;
 
   int workspace_size = compute_multiply_hodlr_dense_workspace(hodlr, matrix_m);
   double *workspace = malloc(workspace_size * sizeof(double));
 
+  int offset = 0;
+  const double alpha = 1.0, beta = 0.0;
+
+  long n_parent_nodes = hodlr->len_work_queue;
   struct HODLRInternalNode **queue = hodlr->work_queue;
   
-  for (int i = 0; i < n_parent_nodes; i++) {
-    queue[i] = hodlr->innermost_leaves[2 * i]->parent;
+  for (int parent = 0; parent < n_parent_nodes; parent++) {
+    queue[parent] = hodlr->innermost_leaves[2 * parent]->parent;
 
     for (int j = 0; j < 2; j++) {
-      m = hodlr->innermost_leaves[idx]->data.diagonal.m;
+      const int m = hodlr->innermost_leaves[2 * parent + j]->data.diagonal.m;
       dgemm_("N", "N", &matrix_m, &m, &m, &alpha, 
              matrix + offset * matrix_ld, &matrix_ld,
-             hodlr->innermost_leaves[idx]->data.diagonal.data, 
+             hodlr->innermost_leaves[2 * parent + j]->data.diagonal.data, 
              &m, &beta, out + offset * out_ld, &out_ld);
       
       offset += m;
-      idx++;
     }
   }
 
   for (int _ = hodlr->height-1; _ > 0; _--) {
     n_parent_nodes /= 2;
-    offset = 0; idx = 0;
+    offset = 0;
 
-    for (int j = 0; j < n_parent_nodes; j++) {
-      for (int k = 0; k < 2; k++) {
-        offset = multiply_dense_off_diagonal(
-          queue[idx], matrix, matrix_m, matrix_ld, out, out_ld, workspace, 
-          offset
+    for (int parent = 0; parent < n_parent_nodes; parent++) {
+      for (int leaf = 0; leaf < 2; leaf++) {
+        offset += multiply_dense_off_diagonal(
+          queue[2 * parent + leaf], 
+          matrix + offset * matrix_ld, matrix_m, matrix_ld, 
+          out + offset * out_ld, out_ld, workspace
         );
-
-        idx++;
       }
 
-      queue[j] = queue[2 * j + 1]->parent;
+      queue[parent] = queue[2 * parent + 1]->parent;
     }
   }
 
   multiply_dense_off_diagonal(
-    hodlr->root, matrix, matrix_m, matrix_ld, out, out_ld, workspace, 0
+    hodlr->root, matrix, matrix_m, matrix_ld, out, out_ld, workspace
   );
 
   free(workspace);
@@ -872,30 +1005,51 @@ double * multiply_dense_hodlr(const struct TreeHODLR *hodlr,
  * Given a dense matrix, and an internal node and its height, computes their
  * product as a dense matrix.
  *
- * :param internal: A pointer to the internal node representing a HODLR matrix
- *                  to multiply. Must not be NULL and must be correctly 
- *                  allocated and fully constructed - anything else is 
- *                  undefined.
- * :param height: The height of the HODLR matrix represented by ``internal``.
- *                This must correspond with the number of internal nodes 
- *                starting from ``internal`` (including) all the way to the 
- *                bottom of the tree.
- * :param matrix: A pointer to access an array containing the matrix to 
- *                multiply. Must not be ``NULL`` and must be large enough to 
- *                store the ``matrix_ld`` x ``matrix_n`` matrix.
- * :param matrix_m: The number of rows of ``matrix`` to multiply.
- * :param matrix_ld: The leading dimension of ``matrix``.
- * :param queue: A pointer to access an array of pointers to internal nodes.
- *               This is a workspace array used to loop over the tree. Must 
- *               not be ``NULL``.
- * :param workspace: A pointer to access an array containing enough space 
- *                   to store an ``s`` x ``matrix_n`` matrix, where ``s`` is 
- *                   the largest number of singular values kept on any leaf 
- *                   node of the ``internal`` tree. Must not be ``NULL``.
- * :param out: A pointer to access an array to be used to save the results.
- *             Must be large enough to store a ``out_ld`` x ``matrix_n`` 
- *             matrix. Must not be ``NULL``.
- * :param out_ld: The leading dimension of ``out``.
+ * Parameters
+ * ----------
+ * internal
+ *     Pointer to the internal node representing a HODLR matrix to be
+ *     multiplied. Must not be ``NULL`` and must be fully constructed - 
+ *     anything else will result in undefined behaviour.
+ * height
+ *     The height of the HODLR matrix represented by ``internal``. This must 
+ *     correspond with the number of internal nodes starting from ``internal`` 
+ *     (including) all the way to the bottom of the tree.
+ * matrix
+ *     Pointer representing an array storing the dense matrix to multiply.
+ *     Must be of size ``matrix_ld`` x M of which a ``matrix_m`` x M submatrix 
+ *     will be used for the multiplication (where M is the number of rows of 
+ *     ``hodlr``). Must be stored in column-major order.
+ *     Must not overlap with ``out`` and must be occupied with values - either 
+ *     will lead to undefined behaviour.
+ *     If ``NULL``, the function will immediately abort.
+ * matrix_m
+ *     The number of rows of ``matrix``.
+ * matrix_ld
+ *     The leading dimension of ``matrix``, i.e. the number of rows of the 
+ *     full matrix. Must be greater than or equal to ``matrix_m``. 
+ * queue
+ *     Pointer representing an array of pointers to internal nodes. This is a 
+ *     workspace array used to loop over the tree. Must be of length at least
+ *     :math:`2^{height-1}`. Must not be ``NULL``.
+ * workspace
+ *     Pointer representing an array to be used as a workspace matrix. Must be 
+ *     of size at least ``s`` x ``matrix_m`` matrix, where ``s`` is the 
+ *     largest rank of any off-diagonal leaf node on the ``internal`` tree. 
+ *     Must not be ``NULL``.
+ * out
+ *     Pointer representing an array to be used for storing the results of the
+ *     multiplication. Must be of size ``out_ld`` x M. Will be stored in 
+ *     column-major order.
+ *     Must not overlap with ``matrix`` as it leads to undefined behaviour, 
+ *     but may be either filled with values (which will be overwritten) or 
+ *     empty (i.e. just allocated).
+ *     If ``NULL``, a new array is allocated.
+ * out_ld
+ *     The leading dimension of ``out``, i.e. the number of rows of the full 
+ *     array. Must be greater than or equal to ``matrix_m``, even if 
+ *     ``out == NULL``, in which case ``out`` will be allocated with size 
+ *     ``out_ld`` x M.
  */
 void multiply_dense_internal_node(
   const struct HODLRInternalNode *restrict const internal,
@@ -903,37 +1057,42 @@ void multiply_dense_internal_node(
   const double *restrict const matrix,
   const int matrix_m,
   const int matrix_ld,
-  const struct HODLRInternalNode **restrict queue,
-  double *restrict workspace,
-  double *restrict out,
+  const struct HODLRInternalNode **queue,
+  double *restrict const workspace,
+  double *restrict const out,
   const int out_ld
 ) {
+  const double alpha = 1.0, beta = 0.0;
+  const int m = internal->children[1].leaf->data.off_diagonal.m;
+
+  multiply_dense_low_rank(
+    &internal->children[1].leaf->data.off_diagonal,
+    matrix, matrix_m, matrix_ld, beta,
+    workspace, out + m * out_ld, out_ld
+  );
+
+  multiply_dense_low_rank(
+    &internal->children[2].leaf->data.off_diagonal,
+    matrix + m * matrix_ld, matrix_m, matrix_ld, beta,
+    workspace, out, out_ld
+  );
+
   int len_queue = 1, q_next_node_density = (int)pow(2, height-1);
   int q_current_node_density = q_next_node_density;
-  int idx = 0, offset = 0;
-  const double alpha = 1.0, beta = 0.0;
-
-  int m = internal->children[1].leaf->data.off_diagonal.m;
-
-  multiply_dense_low_rank(&internal->children[1].leaf->data.off_diagonal,
-                          matrix, matrix_m, matrix_ld, beta,
-                          workspace, out + m * out_ld, out_ld);
-
-  multiply_dense_low_rank(&internal->children[2].leaf->data.off_diagonal,
-                          matrix + m * matrix_ld, matrix_m, matrix_ld, beta,
-                          workspace, out, out_ld);
+  int idx = 0;
 
   queue[0] = internal;
   for (int _ = 1; _ < height; _++) {
     q_next_node_density /= 2;
-    offset = 0;
+    int offset = 0;
 
     for (int parent = 0; parent < len_queue; parent++) {
       idx = parent * q_current_node_density;
       for (int child = 0; child < 4; child += 3) {
-        offset = multiply_dense_off_diagonal(
+        offset += multiply_dense_off_diagonal(
           queue[idx]->children[child].internal,
-          matrix, matrix_m, matrix_ld, out, out_ld, workspace, offset
+          matrix + offset * matrix_ld, matrix_m, matrix_ld, 
+          out + offset * out_ld, out_ld, workspace
         );
       }
 
@@ -945,10 +1104,10 @@ void multiply_dense_internal_node(
     q_current_node_density = q_next_node_density;
   }
 
-  offset = 0;
+  int offset = 0;
   for (int node = 0; node < len_queue; node++) {
     for (int child = 0; child < 4; child+=3) {
-      m = queue[node]->children[child].leaf->data.diagonal.m;
+      const int m = queue[node]->children[child].leaf->data.diagonal.m;
       dgemm_("N", "N", &matrix_m, &m, &m, &alpha, 
              matrix + offset * matrix_ld, &matrix_ld,
              queue[node]->children[child].leaf->data.diagonal.data, &m,

--- a/src/vector_algebra.c
+++ b/src/vector_algebra.c
@@ -124,6 +124,8 @@ static inline unsigned int multiply_off_diagonal_vector(
  * INPUT_ERROR
  *     If ``hodlr`` or ``vector`` is ``NULL`` or if ``vector`` and ``out`` 
  *     point to the same memory location.
+ * ALLOCATION_FAILURE
+ *     If ``out == NULL`` and its allocation fails.
  */
 double * multiply_vector(const struct TreeHODLR *restrict const hodlr,
                          const double *restrict const vector,
@@ -136,6 +138,7 @@ double * multiply_vector(const struct TreeHODLR *restrict const hodlr,
   if (out == NULL) {
     out = malloc(hodlr->root->m * sizeof(double));
     if (out == NULL) {
+      *ierr = ALLOCATION_FAILURE;
       return NULL;
     }
   }

--- a/tests/src/test_hodlr_dense_algebra.c
+++ b/tests/src/test_hodlr_dense_algebra.c
@@ -312,9 +312,13 @@ ParameterizedTest(
               params->hodlr_name, params->hodlr->height, params->dense_name, 
               params->m, params->dense_n, params->dense_ld);
 
+  int ierr;
   double * result = multiply_hodlr_dense(
-    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m
+    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m, 
+    &ierr
   );
+
+  cr_assert(eq(int, ierr, SUCCESS));
 
   double norm, diff;
   expect_matrix_double_eq_safe(
@@ -404,9 +408,13 @@ ParameterizedTest(struct ParametersTestHxD *params, dense_algebra,
               params->hodlr_name, params->hodlr->height, params->dense_name, 
               params->m, params->dense_n, params->dense_ld);
 
+  int ierr;
   double * result = multiply_hodlr_transpose_dense(
-    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m
+    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m,
+    &ierr
   );
+
+  cr_expect(eq(int, ierr, SUCCESS));
 
   double norm, diff;
   expect_matrix_double_eq_safe(result, params->expected, m, params->dense_n, 
@@ -487,16 +495,22 @@ ParameterizedTestParameters(dense_algebra, dense_hodlr) {
 }
 
 
-ParameterizedTest(struct ParametersTestHxD *params, dense_algebra, dense_hodlr) {
+ParameterizedTest(
+  struct ParametersTestHxD *params, dense_algebra, dense_hodlr
+) {
   int m = params->hodlr->root->m;
 
   cr_log_info("%.10s (height=%d) x %.10s (%dx%d, lda=%d)",
               params->hodlr_name, params->hodlr->height, params->dense_name, 
               params->m, params->dense_n, params->dense_ld);
 
+  int ierr;
   double * result = multiply_dense_hodlr(
-    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m
+    params->hodlr, params->dense, params->dense_n, params->dense_ld, NULL, m,
+    &ierr
   );
+
+  cr_expect(eq(int, ierr, SUCCESS));
 
   double norm, diff;
   expect_matrix_double_eq_safe(

--- a/tests/src/test_vector_algebra.c
+++ b/tests/src/test_vector_algebra.c
@@ -186,7 +186,11 @@ ParameterizedTest(struct ParametersTestHxV *params, vector_algebra,
               params->hodlr_name, params->hodlr->height, 
               params->hodlr->root->m, params->vector_name, params->len);
 
-  double * result = multiply_vector(params->hodlr, params->vector, NULL);
+  int ierr;
+  double * result = 
+    multiply_vector(params->hodlr, params->vector, NULL, &ierr);
+
+  cr_expect(eq(int, ierr, SUCCESS));
 
   double norm, diff;
   expect_vector_double_eq_safe(result, params->expected, params->len, 
@@ -340,7 +344,8 @@ ParameterizedTest(struct ParametersTestOffdiagxV *params, vector_algebra,
   double *workspace = malloc(m * sizeof(double));
 
   multiply_off_diagonal_vector(
-    params->parent, params->vector, params->out, workspace, 1, params->offset
+    params->parent, params->vector + params->offset, 
+    params->out + params->offset, workspace
   );
 
   double norm, diff;


### PR DESCRIPTION
Since we are sticking with hawkmoth, adopting the numpydoc style of documentation should make it much more readable in the source code.